### PR TITLE
feat(argo-apps): update argo-rollouts from 2.18 to 2.20

### DIFF
--- a/charts/argo-apps/Chart.yaml
+++ b/charts/argo-apps/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: argo-apps
 description: Argo CD app-of-apps config for various argo project components
 type: application
-version: 0.11.0
+version: 0.12.0
 home: https://github.com/adfinis/helm-charts/tree/main/charts/argo-apps
 sources:
   - https://github.com/adfinis/helm-charts

--- a/charts/argo-apps/README.md
+++ b/charts/argo-apps/README.md
@@ -1,6 +1,6 @@
 # argo-apps
 
-![Version: 0.11.0](https://img.shields.io/badge/Version-0.11.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.12.0](https://img.shields.io/badge/Version-0.12.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Argo CD app-of-apps config for various argo project components
 
@@ -29,7 +29,7 @@ This chart is maintained by [Adfinis](https://adfinis.com/?pk_campaign=github&pk
 | argoRollouts.destination.namespace | string | `"infra-argo-rollouts"` | Namespace |
 | argoRollouts.enabled | bool | `false` | Enable Argo Rollouts |
 | argoRollouts.repoURL | string | [repo](https://argoproj.github.io/argo-helm) | Repo URL |
-| argoRollouts.targetRevision | string | `"2.18.*"` | [argo-rollouts Helm chart](https://github.com/argoproj/argo-helm/tree/master/charts/argo-rollouts) version |
+| argoRollouts.targetRevision | string | `"2.20.*"` | [argo-rollouts Helm chart](https://github.com/argoproj/argo-helm/tree/master/charts/argo-rollouts) version |
 | argoRollouts.values | object | [upstream values](https://github.com/argoproj/argo-helm/blob/master/charts/argo-rollouts/values.yaml) | Helm values |
 | argocdNotifications | object | DEPRECATED | [Argo CD Notifications](https://argocd-notifications.readthedocs.io/en/stable/) is DEPRECATED, use Argo CD directly instead. |
 | argoconfig.application.annotations | object | `{}` | Optional annotations to add to all Applications metadata. |

--- a/charts/argo-apps/values.yaml
+++ b/charts/argo-apps/values.yaml
@@ -33,7 +33,7 @@ argoRollouts:
   # -- Chart
   chart: "argo-rollouts"
   # -- [argo-rollouts Helm chart](https://github.com/argoproj/argo-helm/tree/master/charts/argo-rollouts) version
-  targetRevision: "2.18.*"
+  targetRevision: "2.20.*"
   # -- Helm values
   # @default -- [upstream values](https://github.com/argoproj/argo-helm/blob/master/charts/argo-rollouts/values.yaml)
   values: {}


### PR DESCRIPTION
<!--
    Thank you for your contribution. Please use this template to help guide
    you towards preparing a PR that fullfills our merge requirements.
-->
# Description

Updates the Argo Rollout chart and gives us more control over cluster-role creation as well as the ability to manage secrets in an initContainer.

# Issues

## 2.20

* https://github.com/argoproj/argo-helm/pull/1410
  * [Added]: initContainer option to controller pod, updated secrets roles

## 2.19

* https://github.com/argoproj/argo-helm/pull/1388
  * [Added]: flags to disable the creation of ClusterRoles/ClusterRoleBindings when run in cluster mode

# Checklist

* [x] This PR contains a description of the changes I'm making
* [x] I updated the version in Chart.yaml
* [x] I updated applicable README.md files using  `pre-commit run`
* [x] I documented any high-level concepts I'm introducing in `docs/`
* [x] CI is currently green and this is ready for review
* [x] I am ready to test changes after they are applied and released