### PR TITLE
chore(kps): update to 40.1.*

### DIFF
--- a/charts/infra-apps/Chart.yaml
+++ b/charts/infra-apps/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: infra-apps
 description: Argo CD app-of-apps config for infrastructure components
 type: application
-version: 0.117.0
+version: 0.118.0
 home: https://github.com/adfinis/helm-charts/tree/main/charts/infra-apps
 sources:
   - https://github.com/adfinis/helm-charts

--- a/charts/infra-apps/Chart.yaml
+++ b/charts/infra-apps/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: infra-apps
 description: Argo CD app-of-apps config for infrastructure components
 type: application
-version: 0.116.0
+version: 0.117.0
 home: https://github.com/adfinis/helm-charts/tree/main/charts/infra-apps
 sources:
   - https://github.com/adfinis/helm-charts

--- a/charts/infra-apps/README.md
+++ b/charts/infra-apps/README.md
@@ -1,6 +1,6 @@
 # infra-apps
 
-![Version: 0.116.0](https://img.shields.io/badge/Version-0.116.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.117.0](https://img.shields.io/badge/Version-0.117.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Argo CD app-of-apps config for infrastructure components
 
@@ -78,7 +78,7 @@ This chart is maintained by [Adfinis](https://adfinis.com/?pk_campaign=github&pk
 | kubePrometheusStack.destination.namespace | string | `"infra-monitoring"` | Namespace |
 | kubePrometheusStack.enabled | bool | `false` | Enable prometheus-operator |
 | kubePrometheusStack.repoURL | string | [repo](https://prometheus-community.github.io/helm-charts) | Repo URL |
-| kubePrometheusStack.targetRevision | string | `"36.0.*"` | [kube-prometheus-stack Helm chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack) version |
+| kubePrometheusStack.targetRevision | string | `"40.1.*"` | [kube-prometheus-stack Helm chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack) version |
 | kubePrometheusStack.values | object | [upstream values](https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/values.yaml) | Helm values |
 | kured | object | [example](./examples/kured.yaml) | [kured](https://github.com/kubereboot/kured) |
 | kured.annotations | object | `{}` | Annotations for Kured app |

--- a/charts/infra-apps/README.md
+++ b/charts/infra-apps/README.md
@@ -1,6 +1,6 @@
 # infra-apps
 
-![Version: 0.117.0](https://img.shields.io/badge/Version-0.117.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.118.0](https://img.shields.io/badge/Version-0.118.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Argo CD app-of-apps config for infrastructure components
 

--- a/charts/infra-apps/values.yaml
+++ b/charts/infra-apps/values.yaml
@@ -133,7 +133,7 @@ kubePrometheusStack:
   # -- Chart
   chart: kube-prometheus-stack
   # -- [kube-prometheus-stack Helm chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack) version
-  targetRevision: 36.0.*
+  targetRevision: 40.1.*
   # -- Helm values
   # @default -- [upstream values](https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/values.yaml)
   values: {}


### PR DESCRIPTION
<!--
    Thank you for your contribution. Please use this template to help guide
    you towards preparing a PR that fullfills our merge requirements.
-->
# Description

<!-- Describe the changes your PR introduces here. -->

Updates KubePrometheuStack to `40.1.*`

# Changes

Fixes [CVE-2021-39226](https://github.com/grafana/grafana/security/advisories/GHSA-69j6-29vr-p3j9)

## Prometheus-Operator  0.59.1

* Several bugfixes
* No breaking changes
* https://github.com/prometheus-operator/prometheus-operator/pull/4962
* https://github.com/prometheus-operator/prometheus-operator/pull/4898
* https://github.com/prometheus-operator/prometheus-operator/pull/4622
* https://github.com/prometheus-operator/prometheus-operator/pull/4863
* https://github.com/prometheus-operator/prometheus-operator/pull/4881
* https://github.com/prometheus-operator/prometheus-operator/pull/4834
* https://github.com/prometheus-operator/prometheus-operator/pull/4868
* https://github.com/prometheus-operator/prometheus-operator/pull/4840
* https://github.com/prometheus-operator/prometheus-operator/pull/4873
* https://github.com/prometheus-operator/prometheus-operator/pull/4836

## Prometheus 2.38.0

* Several bugfixes
* No breaking changes
* https://github.com/prometheus/prometheus/pull/10915
* https://github.com/prometheus/prometheus/pull/10759
* https://github.com/prometheus/prometheus/pull/10667
* https://github.com/prometheus/prometheus/pull/10873
* https://github.com/prometheus/prometheus/pull/10874
* https://github.com/prometheus/prometheus/pull/10859
* https://github.com/prometheus/prometheus/pull/10878
* https://github.com/prometheus/prometheus/pull/11020
* https://github.com/prometheus/prometheus/pull/11036
* https://github.com/prometheus/prometheus/pull/10544
* https://github.com/prometheus/prometheus/pull/11005
* https://github.com/prometheus/prometheus/pull/11039
* https://github.com/prometheus/prometheus/pull/10099
* https://github.com/prometheus/prometheus/pull/10993
* https://github.com/prometheus/prometheus/pull/11002
* https://github.com/prometheus/prometheus/pull/11053
* https://github.com/prometheus/prometheus/pull/11034
* https://github.com/prometheus/prometheus/pull/11146
* https://github.com/prometheus/prometheus/pull/10995
* https://github.com/prometheus/prometheus/pull/11068
* https://github.com/prometheus/prometheus/pull/10858
* https://github.com/prometheus/prometheus/pull/9523

## Kube-state-metrics 2.6.0 / helm-chart 4.18.0

### App

* Several bugfixes
* No breaking changes
* https://github.com/kubernetes/kube-state-metrics/pull/1814
* https://github.com/kubernetes/kube-state-metrics/pull/1777
* https://github.com/kubernetes/kube-state-metrics/pull/1799
* https://github.com/kubernetes/kube-state-metrics/pull/1725
* https://github.com/kubernetes/kube-state-metrics/pull/1759
* https://github.com/kubernetes/kube-state-metrics/pull/1773
* https://github.com/kubernetes/kube-state-metrics/pull/1769
* https://github.com/kubernetes/kube-state-metrics/pull/1761
* https://github.com/kubernetes/kube-state-metrics/pull/1766
* https://github.com/kubernetes/kube-state-metrics/pull/1807
* https://github.com/kubernetes/kube-state-metrics/pull/1750
* https://github.com/kubernetes/kube-state-metrics/pull/1812

### Chart

* no breaking changes
* https://github.com/prometheus-community/helm-charts/pull/2213
* https://github.com/prometheus-community/helm-charts/pull/2222
* https://github.com/prometheus-community/helm-charts/pull/2247
* https://github.com/prometheus-community/helm-charts/pull/2249
* https://github.com/prometheus-community/helm-charts/pull/2298
* https://github.com/prometheus-community/helm-charts/pull/2296
* https://github.com/prometheus-community/helm-charts/pull/2370
* https://github.com/prometheus-community/helm-charts/pull/2418
* https://github.com/prometheus-community/helm-charts/pull/2422


## thanos sidecar 0.28.0

* no breaking changes
* pls see the Changelog for the changes introduced in 
* https://github.com/thanos-io/thanos/blob/main/CHANGELOG.md
* https://github.com/thanos-io/thanos/tree/release-0.26
* https://github.com/thanos-io/thanos/tree/release-0.27
* https://github.com/thanos-io/thanos/tree/release-0.28

## prometheus-node-exporter helm chart 4.2.0 (from 3.3.*)

* Starting from prometheus-node-exporter version 4.0.0, the node exporter chart is using the Kubernetes recommended labels. Therefore you have to delete the daemonset before you upgrade. If you use your own custom ServiceMonitor or PodMonitor, please ensure to upgrade their selector fields accordingly to the new labels.


### App

* Stays on version 1.3.1

### Chart

* https://github.com/prometheus-community/helm-charts/pull/2377
* https://github.com/prometheus-community/helm-charts/pull/2212
* https://github.com/prometheus-community/helm-charts/pull/2441
* https://github.com/prometheus-community/helm-charts/pull/2453

## Grafana from 8.5.13 to 9.1.6

* several features, see https://github.com/grafana/grafana/blob/main/CHANGELOG.md
* Breaking changes & deprecations
*  https://github.com/grafana/grafana/blob/main/CHANGELOG.md#breaking-changes-2
* https://github.com/grafana/grafana/blob/main/CHANGELOG.md#deprecations-1
* https://github.com/grafana/grafana/blob/main/CHANGELOG.md#breaking-changes
* https://github.com/grafana/grafana/blob/main/CHANGELOG.md#deprecations

## Others

* Reverted one of the default metrics relabelings for cAdvisor added in 36.x, due to it breaking container_network_* and various other statistics. If you do not want this change, you will need to override the kubelet.cAdvisorMetricRelabelings.

<!--
    Link related issues here, it's ok if this is empty but we do recommend that
    you create issues before working on PRs, issues on internal trackers are
    fine and need not be linked here.
-->

# Checklist

<!--
    Take care of the default items before marking your PR as ready for review,
    be prepared to add more items.
-->

* [x] This PR contains a description of the changes I'm making
* [x] I updated the version in Chart.yaml
* [x] I updated applicable README.md files using  `pre-commit run`
* [x] I documented any high-level concepts I'm introducing in `docs/`
* [x] CI is currently green and this is ready for review
* [x] I am ready to test changes after they are applied and released

<!--
    Please open PRs as Draft while you make CI green and/or finalise
    documentation. Your PR will be assigned to a CODEOWNER once you mark it
    as "Ready for Review".

   Once it is approved we will squash your changes onto the default branch
   and our trusty bot account will release them to the repository.
-->

Signed-off-by: Toni Tauro <toni.tauro@adfinis.com>
