### PR TITLE
fix(timed-backend): increase startup probe failture threshold

### DIFF
--- a/charts/timed/Chart.yaml
+++ b/charts/timed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: timed
 description: Chart for Timed application
 type: application
-version: 0.12.0
+version: 0.12.1
 keywords:
   - timed
   - tracking

--- a/charts/timed/README.md
+++ b/charts/timed/README.md
@@ -1,6 +1,6 @@
 # timed
 
-![Version: 0.12.0](https://img.shields.io/badge/Version-0.12.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.12.1](https://img.shields.io/badge/Version-0.12.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Chart for Timed application
 
@@ -98,6 +98,7 @@ This chart is maintained by [Adfinis](https://adfinis.com/?pk_campaign=github&pk
 | backend.settings.serverEmail | string | `"webmaster@chart-example.local"` | Email address error messages are sent from |
 | backend.settings.workReportPath | string | `"/etc/workreport"` | Path where the workreport shall be loaded from. The contents of the default path is filled from `configmap-workreport.yaml`. |
 | backend.startupProbe.enabled | bool | `true` | Enable startup probe on backend |
+| backend.startupProbe.failureThreshold | int | `6` | Number of times to perform the probe |
 | frontend.image.pullPolicy | string | `"IfNotPresent"` | Frontend image pull policy |
 | frontend.image.repository | string | `"adfinissygroup/timed-frontend"` | Frontend image name |
 | frontend.image.tag | string | `"v2.1.3"` | Frontend version. |

--- a/charts/timed/templates/deployment-backend.yaml
+++ b/charts/timed/templates/deployment-backend.yaml
@@ -57,6 +57,7 @@ spec:
               path: /startup
               port: probe
               scheme: HTTP
+            failureThreshold: {{ .Values.backend.startupProbe.failureThreshold }}
           {{- end}}
           {{- if .Values.backend.livenessProbe.enabled }}
           livenessProbe:

--- a/charts/timed/values.yaml
+++ b/charts/timed/values.yaml
@@ -57,6 +57,8 @@ backend:
   startupProbe:
     # -- Enable startup probe on backend
     enabled: true
+    # -- Number of times to perform the probe
+    failureThreshold: 6
 
   livenessProbe:
     # -- Enable liveness probe on backend


### PR DESCRIPTION
# Description

Overwrite the default failureThreshold to give the timed-backend app some time to come up and prevent
it from startup-loop

# Issues

# Checklist

* [x] This PR contains a description of the changes I'm making
* [x] I updated the version in Chart.yaml
* [x] I updated applicable README.md files using  `pre-commit run`
* [x] I documented any high-level concepts I'm introducing in `docs/`
* [ ] CI is currently green and this is ready for review
* [x] I am ready to test changes after they are applied and released
