### PR TITLE
feat(timed-backend): add env vars to configure hurricane

### DIFF
--- a/charts/timed/Chart.yaml
+++ b/charts/timed/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: timed
 description: Chart for Timed application
 type: application
-version: 0.12.1
+version: 0.13.0
 keywords:
   - timed
   - tracking

--- a/charts/timed/README.md
+++ b/charts/timed/README.md
@@ -1,6 +1,6 @@
 # timed
 
-![Version: 0.12.1](https://img.shields.io/badge/Version-0.12.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.13.0](https://img.shields.io/badge/Version-0.13.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Chart for Timed application
 
@@ -57,7 +57,7 @@ This chart is maintained by [Adfinis](https://adfinis.com/?pk_campaign=github&pk
 | backend.cronjobs.redmineReport | object | `{"command":["./manage.py","redmine_report"],"schedule":"0 1 * * 1"}` | Redmine report |
 | backend.image.pullPolicy | string | `"IfNotPresent"` | Backend image pull policy |
 | backend.image.repository | string | `"ghcr.io/adfinis/timed-backend"` | Backend image name |
-| backend.image.tag | string | `"v3.0.0-rc1"` | Backend version. |
+| backend.image.tag | string | `"v3.0.0-rc2"` | Backend version. |
 | backend.jobs.dbmigrate.enable | bool | `true` | Enable the dbmigrate Job. This is configurable because timed can also run this on startup if so preferred. |
 | backend.livenessProbe.enabled | bool | `true` | Enable liveness probe on backend |
 | backend.livenessProbe.failureThreshold | int | `6` | Number of tries to perform the probe |
@@ -88,8 +88,7 @@ This chart is maintained by [Adfinis](https://adfinis.com/?pk_campaign=github&pk
 | backend.settings.emailFrom | string | `"webmaster@chart-example.local"` | Default email address to use for various responses |
 | backend.settings.emailUrl | string | `"smtp://localhost:25"` | Connection string of SMTP server to send mails |
 | backend.settings.emailUseTls | string | `"True"` | TLS option for email server |
-| backend.settings.gunicorn.cmdArgs | string | `""` | gunicorn additional arguments |
-| backend.settings.gunicorn.workers | int | `8` | Number of gunicorn workers |
+| backend.settings.hurricane.reqQueueLen | int | `250` | request queue length before hurricane denies requests and toggles readiness |
 | backend.settings.maxNumberFields | int | `2000` | Number of fields that are sent when saving changes on a model. |
 | backend.settings.sentry.dsn | string | `nil` | Sentry DSN for error reporting. Set to enable Sentry integration |
 | backend.settings.sentry.enabled | bool | `false` | Enable Sentry integration |

--- a/charts/timed/README.md
+++ b/charts/timed/README.md
@@ -57,7 +57,7 @@ This chart is maintained by [Adfinis](https://adfinis.com/?pk_campaign=github&pk
 | backend.cronjobs.redmineReport | object | `{"command":["./manage.py","redmine_report"],"schedule":"0 1 * * 1"}` | Redmine report |
 | backend.image.pullPolicy | string | `"IfNotPresent"` | Backend image pull policy |
 | backend.image.repository | string | `"ghcr.io/adfinis/timed-backend"` | Backend image name |
-| backend.image.tag | string | `"v3.0.0-rc2"` | Backend version. |
+| backend.image.tag | string | `"v3.0.0-rc3"` | Backend version. |
 | backend.jobs.dbmigrate.enable | bool | `true` | Enable the dbmigrate Job. This is configurable because timed can also run this on startup if so preferred. |
 | backend.livenessProbe.enabled | bool | `true` | Enable liveness probe on backend |
 | backend.livenessProbe.failureThreshold | int | `6` | Number of tries to perform the probe |

--- a/charts/timed/templates/configmap-backend.yaml
+++ b/charts/timed/templates/configmap-backend.yaml
@@ -73,8 +73,7 @@ data:
   DJANGO_REDMINE_HTACCESS_USER: {{ .Values.redmine.htaccessUser | quote }}
   DJANGO_REDMINE_SPENTHOURS_FIELD: {{ .Values.redmine.spenthoursField | quote }}
 {{- end }}
-  GUNICORN_WORKERS: {{ .Values.backend.settings.gunicorn.workers | quote }}
-  GUNICORN_CMD_ARGS: {{ .Values.backend.settings.gunicorn.cmdArgs | quote }}
+  HURRICANE_REQ_QUEUE_LEN: {{ .Values.backend.settings.hurricane.reqQueueLen | quote }}
 {{- if .Values.backend.settings.admins }}
   DJANGO_ADMINS: {{ join "," .Values.backend.settings.admins | quote }}
 {{- end }}

--- a/charts/timed/templates/deployment-backend.yaml
+++ b/charts/timed/templates/deployment-backend.yaml
@@ -33,6 +33,8 @@ spec:
                   fieldPath: status.podIP
             - name: DJANGO_ALLOWED_HOSTS
               value: '{{ join "," .Values.ingress.hosts | default "localhost" }},$(THIS_POD_IP)'
+            - name: HURRICANE_REQ_QUEUE_LEN
+              value: {{ .Values.backend.settings.hurricane.reqQueueLen | quote }}
           envFrom:
             - secretRef:
                 name: {{ include "timed.fullname" . }}-backend

--- a/charts/timed/values.yaml
+++ b/charts/timed/values.yaml
@@ -12,7 +12,7 @@ backend:
     # -- Backend image name
     repository: ghcr.io/adfinis/timed-backend
     # -- Backend version.
-    tag: v3.0.0-rc1
+    tag: v3.0.0-rc2
     # -- Backend image pull policy
     pullPolicy: IfNotPresent
   service:
@@ -104,11 +104,9 @@ backend:
     admins: []
     # -- Define allowed domains for CORS
     corsAllowedOrigins: []
-    gunicorn:
-      # -- Number of gunicorn workers
-      workers: 8
-      # -- gunicorn additional arguments
-      cmdArgs: ""
+    hurricane:
+      # -- request queue length before hurricane denies requests and toggles readiness
+      reqQueueLen: 250
     sentry:
       # -- Enable Sentry integration
       enabled: false

--- a/charts/timed/values.yaml
+++ b/charts/timed/values.yaml
@@ -12,7 +12,7 @@ backend:
     # -- Backend image name
     repository: ghcr.io/adfinis/timed-backend
     # -- Backend version.
-    tag: v3.0.0-rc2
+    tag: v3.0.0-rc3
     # -- Backend image pull policy
     pullPolicy: IfNotPresent
   service:


### PR DESCRIPTION
# Description

This adds the `HURRICANE_REQ_QUEUE_LEN`  environment variable to timed-backend's deployment

# Checklist

<!--
    Take care of the default items before marking your PR as ready for review,
    be prepared to add more items.
-->

* [x] This PR contains a description of the changes I'm making
* [x] I updated the version in Chart.yaml
* [x] I updated applicable README.md files using  `pre-commit run`
* [x] I documented any high-level concepts I'm introducing in `docs/`
* [x] CI is currently green and this is ready for review
* [x] I am ready to test changes after they are applied and released

<!--
    Please open PRs as Draft while you make CI green and/or finalise
    documentation. Your PR will be assigned to a CODEOWNER once you mark it
    as "Ready for Review".

   Once it is approved we will squash your changes onto the default branch
   and our trusty bot account will release them to the repository.
-->
