### PR TITLE
chore(storage/ceph-csi): update to 3.7.1

### DIFF
--- a/charts/storage-apps/Chart.yaml
+++ b/charts/storage-apps/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: storage-apps
 description: Argo CD app-of-apps config for storage applications
 type: application
-version: 0.9.1
+version: 0.10.0
 home: https://github.com/adfinis/helm-charts/tree/main/charts/storage-apps
 sources:
   - https://github.com/adfinis/helm-charts

--- a/charts/storage-apps/README.md
+++ b/charts/storage-apps/README.md
@@ -1,6 +1,6 @@
 # storage-apps
 
-![Version: 0.9.1](https://img.shields.io/badge/Version-0.9.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.10.0](https://img.shields.io/badge/Version-0.10.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Argo CD app-of-apps config for storage applications
 
@@ -28,14 +28,14 @@ This chart is maintained by [Adfinis](https://adfinis.com/?pk_campaign=github&pk
 | cephCsiCephfs.destination.namespace | string | `"infra-storage"` | Namespace |
 | cephCsiCephfs.enabled | bool | `false` | Enable ceph-csi-cephfs |
 | cephCsiCephfs.repoURL | string | [repo](https://ceph.github.io/csi-charts) | Repo URL |
-| cephCsiCephfs.targetRevision | string | `"3.6.*"` | [ceph-csi-cephfs Helm chart](https://github.com/ceph/csi-charts/tree/master/docs/cephfs) version |
+| cephCsiCephfs.targetRevision | string | `"3.7.*"` | [ceph-csi-cephfs Helm chart](https://github.com/ceph/csi-charts/tree/master/docs/cephfs) version |
 | cephCsiCephfs.values | object | [upstream values](https://github.com/ceph/csi-charts/tree/master/docs/cephfs/ceph-csi-cephfs/values.yaml) | Helm values |
 | cephCsiRbd | object | - | [ceph-csi-rbd](https://github.com/ceph/ceph-csi/) |
 | cephCsiRbd.chart | string | `"ceph-csi-rbd"` | Chart |
 | cephCsiRbd.destination.namespace | string | `"infra-storage"` | Namespace |
 | cephCsiRbd.enabled | bool | `false` | Enable ceph-csi-rbd |
 | cephCsiRbd.repoURL | string | [repo](https://ceph.github.io/csi-charts) | Repo URL |
-| cephCsiRbd.targetRevision | string | `"3.6.*"` | [ceph-csi-rbd Helm chart](https://github.com/ceph/csi-charts/tree/master/docs/rbd) version |
+| cephCsiRbd.targetRevision | string | `"3.7.*"` | [ceph-csi-rbd Helm chart](https://github.com/ceph/csi-charts/tree/master/docs/rbd) version |
 | cephCsiRbd.values | object | [upstream values](https://github.com/ceph/csi-charts/tree/master/docs/rbd/ceph-csi-rbd/values.yaml) | Helm values |
 | minio | object | - | [minio](https://github.com/minio/minio) |
 | minio.chart | string | `"minio"` | Chart |

--- a/charts/storage-apps/values.yaml
+++ b/charts/storage-apps/values.yaml
@@ -13,7 +13,7 @@ cephCsiRbd:
   # -- Chart
   chart: "ceph-csi-rbd"
   # -- [ceph-csi-rbd Helm chart](https://github.com/ceph/csi-charts/tree/master/docs/rbd) version
-  targetRevision: "3.6.*"
+  targetRevision: "3.7.*"
   # -- Helm values
   # @default -- [upstream values](https://github.com/ceph/csi-charts/tree/master/docs/rbd/ceph-csi-rbd/values.yaml)
   values: {}
@@ -33,7 +33,7 @@ cephCsiCephfs:
   # -- Chart
   chart: "ceph-csi-cephfs"
   # -- [ceph-csi-cephfs Helm chart](https://github.com/ceph/csi-charts/tree/master/docs/cephfs) version
-  targetRevision: "3.6.*"
+  targetRevision: "3.7.*"
   # -- Helm values
   # @default -- [upstream values](https://github.com/ceph/csi-charts/tree/master/docs/cephfs/ceph-csi-cephfs/values.yaml)
   values: {}


### PR DESCRIPTION

<!--
    Thank you for your contribution. Please use this template to help guide
    you towards preparing a PR that fullfills our merge requirements.
-->
# Description

updates ceph-csi applications to use 3.7.x version of the chart
<!-- Describe the changes your PR introduces here. -->

# Issues

#803
#804

<!--
    Link related issues here, it's ok if this is empty but we do recommend that
    you create issues before working on PRs, issues on internal trackers are
    fine and need not be linked here.
-->
# Changes


## New Features:

* NFS
  * Added support for volume expansion, snapshot, restore and clone.
  * Added NFS nodeserver within CephCSI with support for pod networking with nsenter.
* Support enabling PV and snapshot metadata on the RBD images and CephFS subvolumes
  * For persistent volumes, clones and volume restores we support adding PVName/PVCName/PVCNamespace and ClusterName details
  * For snapshot volumes we support adding snapshot-name/snapshot-namespace/snapshotcontent-name and ClusterName details
* Shallow Read Only support for Ceph CSI driver:
  * cephfs-csi expose CephFS snapshots as shallow, read-only volumes, without needing to clone the underlying snapshot data (https://github.com/ceph/ceph-csi/blob/devel/docs/design/proposals/cephfs-snapshot-shallow-ro-vol.md ) which enables users to Restore snapshots selectively - users may want to traverse snapshots, restoring data to a writable volume more selectively instead of restoring the whole snapshot and this feature also help to perform more efficient Volume backup.
* All kubernetes sidecars ( external provisioner,snapshotter, resizer..etc) are rebased to latest available versions. Along with other dependency module updates this release consume go-ceph v0.17.0 and kubernetes 1.24.4 version.
* snapshot API support has been lifted to GA version in this release.
* From this release onwards, the CSI driver make use of File fsgroup policy for its fsgroup based operations.
* New feature gates are enabled ( HonorPVReclaimPolicy..etc) in the sidecar deployments.


## Deprecations:

* https://github.com/ceph/ceph-csi/issues/3314
* https://github.com/ceph/ceph-csi/pull/3149

## Breaking Changes

* NFS daemonset is renamed from csi-nfs-node to csi-nfsplugin, refer to upgrade steps for more details.
<!--
    Take care of the default items before marking your PR as ready for review,
    be prepared to add more items.
-->
# Checklist

* [x] This PR contains a description of the changes I'm making
* [x] I updated the version in Chart.yaml
* [x] I updated applicable README.md files using  `pre-commit run`
* [x] I documented any high-level concepts I'm introducing in `docs/`
* [x] CI is currently green and this is ready for review
* [x] I am ready to test changes after they are applied and released

<!--
    Please open PRs as Draft while you make CI green and/or finalise
    documentation. Your PR will be assigned to a CODEOWNER once you mark it
    as "Ready for Review".

   Once it is approved we will squash your changes onto the default branch
   and our trusty bot account will release them to the repository.
-->
