### PR TITLE
fix(openshift-etcd-backup): update from 1.6.5 to 1.6.6

### DIFF
--- a/charts/openshift-etcd-backup/Chart.yaml
+++ b/charts/openshift-etcd-backup/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: openshift-etcd-backup
 description: Chart for openshift-etcd-backup solution
 type: application
-version: 1.6.5
-appVersion: v1.6.5
+version: 1.6.6
+appVersion: v1.6.6
 keywords:
   - openshift-etcd-backup
   - openshift

--- a/charts/openshift-etcd-backup/README.md
+++ b/charts/openshift-etcd-backup/README.md
@@ -1,6 +1,6 @@
 # openshift-etcd-backup
 
-![Version: 1.6.5](https://img.shields.io/badge/Version-1.6.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.6.5](https://img.shields.io/badge/AppVersion-v1.6.5-informational?style=flat-square)
+![Version: 1.6.6](https://img.shields.io/badge/Version-1.6.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.6.6](https://img.shields.io/badge/AppVersion-v1.6.6-informational?style=flat-square)
 
 Chart for openshift-etcd-backup solution
 


### PR DESCRIPTION
<!--
    Thank you for your contribution. Please use this template to help guide
    you towards preparing a PR that fullfills our merge requirements.
-->
# Description

Update the ubi8 base image used for openshift-etcd-backup from 8.6-902.1661794353 to 8.6-994.

# Issues

* https://github.com/adfinis/openshift-etcd-backup/pull/37
* https://github.com/adfinis/openshift-etcd-backup/releases/tag/v1.6.6

# Checklist

<!--
    Take care of the default items before marking your PR as ready for review,
    be prepared to add more items.
-->

* [x] This PR contains a description of the changes I'm making
* [x] I updated the version in Chart.yaml
* [x] I updated applicable README.md files using  `pre-commit run`
* [x] I documented any high-level concepts I'm introducing in `docs/`
* [x] CI is currently green and this is ready for review
* [ ] I am ready to test changes after they are applied and released

<!--
    Please open PRs as Draft while you make CI green and/or finalise
    documentation. Your PR will be assigned to a CODEOWNER once you mark it
    as "Ready for Review".

   Once it is approved we will squash your changes onto the default branch
   and our trusty bot account will release them to the repository.
-->
