### PR TITLE
feat(logging-apps): update otel-collector from 0.20.2 to 0.38.1

### DIFF
--- a/charts/tracing-apps/Chart.yaml
+++ b/charts/tracing-apps/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tracing-apps
 description: Argo CD app-of-apps config for tracing applications
 type: application
-version: 0.16.0
+version: 0.17.0
 home: https://github.com/adfinis/helm-charts/tree/main/charts/tracing-apps
 sources:
   - https://github.com/adfinis/helm-charts
@@ -17,17 +17,112 @@ dependencies:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "Update Jaeger Operator to 1.36.0"
+      description: 'add support for hostnetworking in deployment and statefulset mode'
       links:
         - name: GitHub PR
-          url: https://github.com/jaegertracing/helm-charts/pull/392
+          url: https://github.com/open-telemetry/opentelemetry-helm-charts/pull/469
     - kind: changed
-      description: "Update Jaeger Operator to 1.37.0"
+      description: 'Bump collector version to 0.63.1'
       links:
         - name: GitHub PR
-          url: https://github.com/jaegertracing/helm-charts/pull/398
+          url: https://github.com/open-telemetry/opentelemetry-helm-charts/pull/475
     - kind: changed
-      description: "Update Jaeger Operator to 1.38.0"
+      description: 'add kubeletMetrics preset'
       links:
         - name: GitHub PR
-          url: https://github.com/jaegertracing/helm-charts/pull/405
+          url: https://github.com/open-telemetry/opentelemetry-helm-charts/pull/468
+    - kind: changed
+      description: 'Reorder preset processors'
+      links:
+        - name: GitHub PR
+          url: https://github.com/open-telemetry/opentelemetry-helm-charts/pull/471
+    - kind: changed
+      description: 'add cluster metrics preset'
+      links:
+        - name: GitHub PR
+          url: https://github.com/open-telemetry/opentelemetry-helm-charts/pull/454
+    - kind: changed
+      description: 'cleanup log preset attributes'
+      links:
+        - name: GitHub PR
+          url: https://github.com/open-telemetry/opentelemetry-helm-charts/pull/455
+    - kind: changed
+      description: 'Add annotations to statefulsets and daemonsets'
+      links:
+        - name: GitHub PR
+          url: https://github.com/open-telemetry/opentelemetry-helm-charts/pull/424
+    - kind: changed
+      description: 'Allow service/ingress exposure in any mode'
+      links:
+        - name: GitHub PR
+          url: https://github.com/open-telemetry/opentelemetry-helm-charts/pull/427
+    - kind: changed
+      description: 'Bump collector version to 0.62.1'
+      links:
+        - name: GitHub PR
+          url: https://github.com/open-telemetry/opentelemetry-helm-charts/pull/428
+    - kind: changed
+      description: 'Bump collector version to 0.62.0'
+      links:
+        - name: GitHub PR
+          url: https://github.com/open-telemetry/opentelemetry-helm-charts/pull/418
+    - kind: changed
+      description: 'add kubernetes attributes processor'
+      links:
+        - name: GitHub PR
+          url: https://github.com/open-telemetry/opentelemetry-helm-charts/pull/412
+    - kind: changed
+      description: 'Use tpl with configmap'
+      links:
+        - name: GitHub PR
+          url: https://github.com/open-telemetry/opentelemetry-helm-charts/pull/395
+    - kind: changed
+      description: 'bump collector version'
+      links:
+        - name: GitHub PR
+          url: https://github.com/open-telemetry/opentelemetry-helm-charts/pull/393
+    - kind: changed
+      description: 'Add Update Strategy to Control Rollout'
+      links:
+        - name: GitHub PR
+          url: https://github.com/open-telemetry/opentelemetry-helm-charts/pull/382
+    - kind: changed
+      description: 'fix: Use port number instead of name in targetPort'
+      links:
+        - name: GitHub PR
+          url: https://github.com/open-telemetry/opentelemetry-helm-charts/pull/378
+    - kind: changed
+      description: 'fix: logsCollection use resouce attributes'
+      links:
+        - name: GitHub PR
+          url: https://github.com/open-telemetry/opentelemetry-helm-charts/pull/375
+    - kind: changed
+      description: 'fix: logsCollection CRI regex'
+      links:
+        - name: GitHub PR
+          url: https://github.com/open-telemetry/opentelemetry-helm-charts/pull/377
+    - kind: changed
+      description: 'fixed volumeClaimTemplate of the statefulset mode'
+      links:
+        - name: GitHub PR
+          url: https://github.com/open-telemetry/opentelemetry-helm-charts/pull/373
+    - kind: changed
+      description: 'Remove deprecated containerLogs option'
+      links:
+        - name: GitHub PR
+          url: https://github.com/open-telemetry/opentelemetry-helm-charts/pull/366
+    - kind: changed
+      description: '[chore] Bump default image for opentelemetry-collector chart'
+      links:
+        - name: GitHub PR
+          url: https://github.com/open-telemetry/opentelemetry-helm-charts/pull/364
+    - kind: changed
+      description: 'bump version to 0.59.0'
+      links:
+        - name: GitHub PR
+          url: https://github.com/open-telemetry/opentelemetry-helm-charts/pull/349
+    - kind: changed
+      description: 'set proper resources for collector'
+      links:
+        - name: GitHub PR
+          url: https://github.com/open-telemetry/opentelemetry-helm-charts/pull/273

--- a/charts/tracing-apps/README.md
+++ b/charts/tracing-apps/README.md
@@ -1,6 +1,6 @@
 # tracing-apps
 
-![Version: 0.16.0](https://img.shields.io/badge/Version-0.16.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.17.0](https://img.shields.io/badge/Version-0.17.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Argo CD app-of-apps config for tracing applications
 
@@ -35,7 +35,7 @@ This chart is maintained by [Adfinis](https://adfinis.com/?pk_campaign=github&pk
 | opentelemetryCollector.destination.namespace | string | `"infra-otel-operator"` | Namespace |
 | opentelemetryCollector.enabled | bool | `false` | Enable otel-exporter |
 | opentelemetryCollector.repoURL | string | [repo](https://open-telemetry.github.io/opentelemetry-helm-charts) | Repo URL |
-| opentelemetryCollector.targetRevision | string | `"0.20.2"` | [opentelemetry-collector Helm chart](https://github.com/open-telemetry/opentelemetry-helm-charts/tree/main/charts/opentelemetry-collector) |
+| opentelemetryCollector.targetRevision | string | `"0.38.1"` | [opentelemetry-collector Helm chart](https://github.com/open-telemetry/opentelemetry-helm-charts/tree/main/charts/opentelemetry-collector) |
 | opentelemetryCollector.values | object | [upstream values](https://github.com/open-telemetry/opentelemetry-helm-charts/blob/main/charts/opentelemetry-collector/values.yaml) | Helm values |
 
 ## About this chart

--- a/charts/tracing-apps/values.yaml
+++ b/charts/tracing-apps/values.yaml
@@ -33,7 +33,7 @@ opentelemetryCollector:
   # -- Chart
   chart: "opentelemetry-collector"
   # -- [opentelemetry-collector Helm chart](https://github.com/open-telemetry/opentelemetry-helm-charts/tree/main/charts/opentelemetry-collector)
-  targetRevision: "0.20.2"
+  targetRevision: "0.38.1"
   # -- Helm values
   # @default -- [upstream values](https://github.com/open-telemetry/opentelemetry-helm-charts/blob/main/charts/opentelemetry-collector/values.yaml)
   values: {}


### PR DESCRIPTION
<!--
    Thank you for your contribution. Please use this template to help guide
    you towards preparing a PR that fullfills our merge requirements.
-->
# Description

Update otel-collector to the latest version. Bumps actual collector version from 0.53.0 to 0.63.1 and chart has a buch of changes described below. The main change is that the config needs updating to use the new `mode` value.

## logging-apps 0.16.0 to 0.17.0

### otel-collector

See otel-collector's [UPGRADING.md](https://github.com/open-telemetry/opentelemetry-helm-charts/blob/main/charts/opentelemetry-collector/UPGRADING.md) for up2date data.

#### config supports templating

The chart now supports templating in `.Values.config`.  If you are currently using any `{{ }}` syntax in `.Values.yaml` it will now be rendered.  To escape existing instances of `{{ }}`, use ``` {{` <original content> `}} ```.  For example, `{{ REDACTED_EMAIL }}` becomes ``` {{` {{ REDACTED_EMAIL }} `}} ```.

#### [Reduce requested resources](https://github.com/open-telemetry/opentelemetry-helm-charts/pull/273)

Resource `limits` have been reduced. Upgrades/installs of chart 0.29.0 will now use fewer resources. In order to set the resources back to what they were, you will need to override the `resources` section in the `values.yaml`.

*Example*:

```yaml
resources:
  limits:
    cpu: 1
    memory: 2Gi
```

#### Remove containerLogs in favor of presets.logsCollection

The ability to enable logs collection from the collector has been moved from `containerLogs.enabled` to `presets.logsCollection.enabled`. If you are currently using `containerLogs.enabled`, you should instead use the preset:

```yaml
presets:
  logsCollection:
    enabled: true
```

If you are using `containerLogs.enabled` and also enabling collection of the collector logs you can use `includeCollectorLogs`

```yaml
presets:
  logsCollection:
    enabled: true
    includeCollectorLogs: true
```

You no longer need to update `config.service.pipelines.logs` to include the filelog receiver yourself as the preset will automatically update the logs pipeline to include the filelog receiver.

The filelog's preset configuration can modified by `config.receivers`, but preset configuration cannot be removed.  If you need to remove any filelog receiver configuration generated by the preset you should not use the preset.  Instead, configure the filelog receiver manually in `config.receivers` and set any other necessary fields in the values.yaml to modify k8s as needed.

See the [daemonset-collector-logs example](https://github.com/open-telemetry/opentelemetry-helm-charts/tree/main/charts/opentelemetry-collector/examples/daemonset-collector-logs) to see an example of the preset in action.

# Issues

<!--
    Link related issues here, it's ok if this is empty but we do recommend that
    you create issues before working on PRs, issues on internal trackers are
    fine and need not be linked here.
-->

# Checklist

<!--
    Take care of the default items before marking your PR as ready for review,
    be prepared to add more items.
-->

* [x] This PR contains a description of the changes I'm making
* [x] I updated the version in Chart.yaml
* [x] I updated applicable README.md files using  `pre-commit run`
* [x] I documented any high-level concepts I'm introducing in `docs/`
* [x] CI is currently green and this is ready for review
* [x] I am ready to test changes after they are applied and released

<!--
    Please open PRs as Draft while you make CI green and/or finalise
    documentation. Your PR will be assigned to a CODEOWNER once you mark it
    as "Ready for Review".

   Once it is approved we will squash your changes onto the default branch
   and our trusty bot account will release them to the repository.
-->
