### PR TITLE
feat(infra-apps): upgrade kube-prometheus-stack from 40.1 to 41.7.4

### DIFF
--- a/charts/infra-apps/Chart.yaml
+++ b/charts/infra-apps/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: infra-apps
 description: Argo CD app-of-apps config for infrastructure components
 type: application
-version: 0.124.1
+version: 0.125.0
 home: https://github.com/adfinis/helm-charts/tree/main/charts/infra-apps
 sources:
   - https://github.com/adfinis/helm-charts
@@ -17,12 +17,132 @@ dependencies:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "fix(argo-cd): Upgrade Argo Image to the latest version 2.5.1"
+      description: "bump grafana chart dependency to 6.43.5"
       links:
         - name: GitHub PR
-          url: https://github.com/argoproj/argo-helm/pull/1614
-    - kind: added
-      description: "feat(argo-cd): Add revisionHistoryLimit"
+          url: https://github.com/argoproj/argo-helm/pull/2674
+    - kind: changed
+      description: "Bump kube-state-metrics version"
       links:
         - name: GitHub PR
-          url: https://github.com/argoproj/argo-helm/pull/1599
+          url: https://github.com/argoproj/argo-helm/pull/2636
+    - kind: changed
+      description: "avoid alerting field in prometheus CR, if alertmanager config is empty"
+      links:
+        - name: GitHub PR
+          url: https://github.com/argoproj/argo-helm/pull/2600
+    - kind: changed
+      description: "Fix for alert mgr service monitor: enableHttp2"
+      links:
+        - name: GitHub PR
+          url: https://github.com/argoproj/argo-helm/pull/2570
+    - kind: changed
+      description: "Bump prometheus-node-exporter subchart version"
+      links:
+        - name: GitHub PR
+          url: https://github.com/argoproj/argo-helm/pull/2619
+    - kind: changed
+      description: "Remove desaintmartin from maintainers."
+      links:
+        - name: GitHub PR
+          url: https://github.com/argoproj/argo-helm/pull/2604
+    - kind: changed
+      description: "bump grafana 6.43.0 (9.2.1)"
+      links:
+        - name: GitHub PR
+          url: https://github.com/argoproj/argo-helm/pull/2602
+    - kind: changed
+      description: "fix network policy api template"
+      links:
+        - name: GitHub PR
+          url: https://github.com/argoproj/argo-helm/pull/2586
+    - kind: changed
+      description: "add network policies"
+      links:
+        - name: GitHub PR
+          url: https://github.com/argoproj/argo-helm/pull/2580
+    - kind: changed
+      description: "PodSecurityPolicy being removed from Kubernetes"
+      links:
+        - name: GitHub PR
+          url: https://github.com/argoproj/argo-helm/pull/2561
+    - kind: changed
+      description: "Add Vertical Pod Autoscaler to Prometheus Operator"
+      links:
+        - name: GitHub PR
+          url: https://github.com/argoproj/argo-helm/pull/2552
+    - kind: changed
+      description: "Fix generated label for Prometheus Pod anti-affinity"
+      links:
+        - name: GitHub PR
+          url: https://github.com/argoproj/argo-helm/pull/2554
+    - kind: changed
+      description: "fix servicemonitor"
+      links:
+        - name: GitHub PR
+          url: https://github.com/argoproj/argo-helm/pull/2549
+    - kind: changed
+      description: "Allow annotations on the admissionWebhook Jobs"
+      links:
+        - name: GitHub PR
+          url: https://github.com/argoproj/argo-helm/pull/2528
+    - kind: changed
+      description: "Alert mgr service monitor: enableHttp2"
+      links:
+        - name: GitHub PR
+          url: https://github.com/argoproj/argo-helm/pull/2540
+    - kind: changed
+      description: "Add additionalArgs support to PrometheusSpec"
+      links:
+        - name: GitHub PR
+          url: https://github.com/argoproj/argo-helm/pull/2482
+    - kind: changed
+      description: "fix versions"
+      links:
+        - name: GitHub PR
+          url: https://github.com/argoproj/argo-helm/pull/2546
+    - kind: changed
+      description: "prom operator update / add recording and alerting switch to kubeScheduler"
+      links:
+        - name: GitHub PR
+          url: https://github.com/argoproj/argo-helm/pull/2410
+    - kind: changed
+      description: "Update Prometheus to v2.39.0"
+      links:
+        - name: GitHub PR
+          url: https://github.com/argoproj/argo-helm/pull/2524
+    - kind: changed
+      description: "Add queryConfig to thanosRulerSpec"
+      links:
+        - name: GitHub PR
+          url: https://github.com/argoproj/argo-helm/pull/2522
+    - kind: changed
+      description: "BUMP ksm helm dep"
+      links:
+        - name: GitHub PR
+          url: https://github.com/argoproj/argo-helm/pull/2509
+    - kind: changed
+      description: "prometheus-operator0.59.2/dependencies"
+      links:
+        - name: GitHub PR
+          url: https://github.com/argoproj/argo-helm/pull/2505
+    - kind: changed
+      description: "Add ability to add custom labels in the operator deployment"
+      links:
+        - name: GitHub PR
+          url: https://github.com/argoproj/argo-helm/pull/2492
+    - kind: changed
+      description: "helm dependency update"
+      links:
+        - name: GitHub PR
+          url: https://github.com/argoproj/argo-helm/pull/2485
+    - kind: changed
+      description: "Add template option to namespaces flag"
+      links:
+        - name: GitHub PR
+          url: https://github.com/argoproj/argo-helm/pull/2466
+    - kind: changed
+      description: "Add support for StatefulSet minReadySeconds"
+      links:
+        - name: GitHub PR
+          url: https://github.com/argoproj/argo-helm/pull/2463

--- a/charts/infra-apps/README.md
+++ b/charts/infra-apps/README.md
@@ -1,6 +1,6 @@
 # infra-apps
 
-![Version: 0.124.1](https://img.shields.io/badge/Version-0.124.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.125.0](https://img.shields.io/badge/Version-0.125.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Argo CD app-of-apps config for infrastructure components
 
@@ -78,7 +78,7 @@ This chart is maintained by [Adfinis](https://adfinis.com/?pk_campaign=github&pk
 | kubePrometheusStack.destination.namespace | string | `"infra-monitoring"` | Namespace |
 | kubePrometheusStack.enabled | bool | `false` | Enable prometheus-operator |
 | kubePrometheusStack.repoURL | string | [repo](https://prometheus-community.github.io/helm-charts) | Repo URL |
-| kubePrometheusStack.targetRevision | string | `"40.1.*"` | [kube-prometheus-stack Helm chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack) version |
+| kubePrometheusStack.targetRevision | string | `"41.7.4"` | [kube-prometheus-stack Helm chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack) version |
 | kubePrometheusStack.values | object | [upstream values](https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/values.yaml) | Helm values |
 | kured | object | [example](./examples/kured.yaml) | [kured](https://github.com/kubereboot/kured) |
 | kured.annotations | object | `{}` | Annotations for Kured app |

--- a/charts/infra-apps/values.yaml
+++ b/charts/infra-apps/values.yaml
@@ -133,7 +133,7 @@ kubePrometheusStack:
   # -- Chart
   chart: kube-prometheus-stack
   # -- [kube-prometheus-stack Helm chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack) version
-  targetRevision: 40.1.*
+  targetRevision: 41.7.4
   # -- Helm values
   # @default -- [upstream values](https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/values.yaml)
   values: {}


### PR DESCRIPTION
<!--
    Thank you for your contribution. Please use this template to help guide
    you towards preparing a PR that fullfills our merge requirements.
-->
# Description

Most contains a bunch of low-level fixed and updates to components like grafana, kube-state-metrics, prometheus-node-exporter, and helm.

# Upgrading

## From 40.x to 41.x

This version upgrades Prometheus-Operator to v0.60.1, Prometheus to v2.39.1 and Thanos to v0.28.1.
This version also upgrades the Helm charts of kube-state-metrics to 4.20.2, prometheus-node-exporter to 4.3.0 and Grafana to 6.40.4.

Run these commands to update the CRDs before applying the upgrade.

```console
kubectl apply --server-side -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.60.1/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml
kubectl apply --server-side -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.60.1/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
kubectl apply --server-side -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.60.1/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml
kubectl apply --server-side -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.60.1/example/prometheus-operator-crd/monitoring.coreos.com_probes.yaml
kubectl apply --server-side -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.60.1/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
kubectl apply --server-side -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.60.1/example/prometheus-operator-crd/monitoring.coreos.com_prometheusrules.yaml
kubectl apply --server-side -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.60.1/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
kubectl apply --server-side -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.60.1/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
```

This version splits kubeScheduler recording and altering rules in separate config values.
Instead of `defaultRules.rules.kubeScheduler` the 2 new variables `defaultRules.rules.kubeSchedulerAlerting` and `defaultRules.rules.kubeSchedulerRecording` are used.

# Issues

<!--
    Link related issues here, it's ok if this is empty but we do recommend that
    you create issues before working on PRs, issues on internal trackers are
    fine and need not be linked here.
-->

# Checklist

<!--
    Take care of the default items before marking your PR as ready for review,
    be prepared to add more items.
-->

* [x] This PR contains a description of the changes I'm making
* [x] I updated the version in Chart.yaml
* [x] I updated applicable README.md files using  `pre-commit run`
* [x] I documented any high-level concepts I'm introducing in `docs/`
* [x] CI is currently green and this is ready for review
* [x] I am ready to test changes after they are applied and released

<!--
    Please open PRs as Draft while you make CI green and/or finalise
    documentation. Your PR will be assigned to a CODEOWNER once you mark it
    as "Ready for Review".

   Once it is approved we will squash your changes onto the default branch
   and our trusty bot account will release them to the repository.
-->
