### PR TITLE
chore(mimir): update to 3.3.*

### DIFF
--- a/charts/infra-apps/Chart.yaml
+++ b/charts/infra-apps/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: infra-apps
 description: Argo CD app-of-apps config for infrastructure components
 type: application
-version: 0.130.0
+version: 0.131.0
 home: https://github.com/adfinis/helm-charts/tree/main/charts/infra-apps
 sources:
   - https://github.com/adfinis/helm-charts
@@ -17,22 +17,7 @@ dependencies:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "feat(kured): update chart to 1.11.0"
-      links:
-        - name: GitHub Commit
-          url: https://github.com/kubereboot/charts/commit/c3656490312fb42ad79605cf3609ed0d55c9395e
-    - kind: added
-      description: "feat(kured): Add hostNetwork option"
+      description: "mimir chart 3.3.0 with GEM 2.4.0"
       links:
         - name: GitHub PR
-          url: https://github.com/kubereboot/charts/pull/16
-    - kind: changed
-      description: "feat(ingress): fix wrong indention on skipWaitForDeleteTimeout"
-      links:
-        - name: GitHub PR
-          url: https://github.com/kubereboot/charts/pull/17
-    - kind: changed
-      description: "feat(ingress): Revert 'Temporarily revert to dockerhub'"
-      links:
-        - name: GitHub PR
-          url: https://github.com/kubereboot/charts/pull/4
+          url: https://github.com/grafana/mimir/pull/3445

--- a/charts/infra-apps/README.md
+++ b/charts/infra-apps/README.md
@@ -1,6 +1,6 @@
 # infra-apps
 
-![Version: 0.130.0](https://img.shields.io/badge/Version-0.130.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.131.0](https://img.shields.io/badge/Version-0.131.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Argo CD app-of-apps config for infrastructure components
 
@@ -94,7 +94,7 @@ This chart is maintained by [Adfinis](https://adfinis.com/?pk_campaign=github&pk
 | mimir.destination.namespace | string | `"infra-mimir"` | Namespace |
 | mimir.enabled | bool | `false` | Enable mimir |
 | mimir.repoURL | string | [repo](https://grafana.github.io/helm-charts) | Repo URL |
-| mimir.targetRevision | string | `"3.1.*"` | [mimir Helm chart](https://github.com/grafana/mimir/tree/main/operations/helm/charts/mimir-distributed) |
+| mimir.targetRevision | string | `"3.3.*"` | [mimir Helm chart](https://github.com/grafana/mimir/tree/main/operations/helm/charts/mimir-distributed) |
 | mimir.values | object | [upstream values](https://github.com/grafana/mimir/tree/main/operations/helm/charts/mimir-distributed/values.yaml) | Helm values |
 | rbacManager | object | [example](./examples/rbac-manager.yaml) | [rbac-manager](https://fairwindsops.github.io/rbac-manager/) |
 | rbacManager.annotations | object | `{}` | Annotations for rbac-manager app |

--- a/charts/infra-apps/values.yaml
+++ b/charts/infra-apps/values.yaml
@@ -265,7 +265,7 @@ mimir:
   # -- Chart
   chart: mimir-distributed
   # -- [mimir Helm chart](https://github.com/grafana/mimir/tree/main/operations/helm/charts/mimir-distributed)
-  targetRevision: 3.1.*
+  targetRevision: 3.3.*
   # -- Helm values
   # @default -- [upstream values](https://github.com/grafana/mimir/tree/main/operations/helm/charts/mimir-distributed/values.yaml)
   values: {}


### PR DESCRIPTION
# Description

Updates mimir chart to version 3.3.*

# Issues

Fixes #868

# Changes

- add `kubeVersionOverride` value (default `null`)
- set `image.tag` to `2.4.0`
- set `enterprise.image.tag` to `2.4.0`
- remove `*.affinity` defaults values
- add `*.topologySpreadConstraints` block
- add `nginx.route` block (for OpenShift)
- add `metaMonitoring.grafanaAgent.logs.enabled` (default `true`)
- add `metaMonitoring.grafanaAgent.metrics.enabled` (default `true`)

# Checklist

* [x] This PR contains a description of the changes I'm making
* [x] I updated the version in Chart.yaml
* [x] I updated applicable README.md files using  `pre-commit run`
* [x] I documented any high-level concepts I'm introducing in `docs/`
* [ ] CI is currently green and this is ready for review
* [x] I am ready to test changes after they are applied and released
