### PR TITLE
Update PR template adding the changelog as todo

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -23,6 +23,7 @@
 
 * [ ] This PR contains a description of the changes I'm making
 * [ ] I updated the version in Chart.yaml
+* [ ] I updated the changelog according to the `artifacthub.io/changes` annotation
 * [ ] I updated applicable README.md files using  `pre-commit run`
 * [ ] I documented any high-level concepts I'm introducing in `docs/`
 * [ ] CI is currently green and this is ready for review


### PR DESCRIPTION
We agreed on creating a `artifacthub.io/changes` style changelog when updating the helm charts. So we want to reflect this in the PR template checklist.


No issue was created for this, since it’s a veeeery small change.

