### PR TITLE
feat(infra-apps): update kube-prometheus-stack from 42.1.0 to 44.2.1

### DIFF
--- a/charts/infra-apps/Chart.yaml
+++ b/charts/infra-apps/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: infra-apps
 description: Argo CD app-of-apps config for infrastructure components
 type: application
-version: 0.139.1
+version: 0.140.0
 home: https://github.com/adfinis/helm-charts/tree/main/charts/infra-apps
 sources:
   - https://github.com/adfinis/helm-charts
@@ -17,7 +17,92 @@ dependencies:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "New GitHub repository for Kubernetes-Event-Exporter"
+      description: "Registry change for upstream kube-webhook-certgen"
       links:
-        - name: GitHub repository
-          url: https://github.com/resmoio/kubernetes-event-exporter
+        - name: GitHub PR
+          url: https://github.com/prometheus-community/helm-charts/pull/2924
+    - kind: changed
+      description: "add alertmanagerConfigMatcherStrategy for alertmanager"
+      links:
+        - name: GitHub PR
+          url: https://github.com/prometheus-community/helm-charts/pull/2882
+    - kind: changed
+      description: "Add support for hostAliases in prometheus"
+      links:
+        - name: GitHub PR
+          url: https://github.com/prometheus-community/helm-charts/pull/2780
+    - kind: changed
+      description: "More secure admissionWebhooks failurePolicy"
+      links:
+        - name: GitHub PR
+          url: https://github.com/prometheus-community/helm-charts/pull/2911
+    - kind: changed
+      description: "modify prometheusOperator.serviceMonitor.sampleLimit default value 0 (mean no limit)"
+      links:
+        - name: GitHUb PR
+          url: https://github.com/prometheus-community/helm-charts/pull/2913
+    - kind: changed
+      description: "add servicemonitor/podmonitor scrape limits"
+      links:
+        - name: GitHub PR
+          url: https://github.com/prometheus-community/helm-charts/pull/2615
+    - kind: changed
+      description: "Bump version to force use of new versions of subcharts"
+      links:
+        - name: GitHub PR
+          url: https://github.com/prometheus-community/helm-charts/pull/2867
+    - kind: changed
+      description: "updates alertmanager image to v0.25.0"
+      links:
+        - name: GitHub PR
+          url: https://github.com/prometheus-community/helm-charts/pull/2860
+    - kind: changed
+      description: "Add IsDefaultDatasource for editing isDefault value for another DS"
+      links:
+        - name: GitHub PR
+          url: Add IsDefaultDatasource for editing isDefault value for another DS
+    - kind: changed
+      description: "Remove ruleNamespaceSelector and ruleSelector from CRD, if enableFeatures contains agent"
+      links:
+        - name: GitHub PR
+          url: Remove ruleNamespaceSelector and ruleSelector from CRD, if enableFeatures contains agent
+    - kind: changed
+      description: "Fix prometheus-operator VPA targetRef"
+      links:
+        - name: GitHUb PR
+          url: "https://github.com/prometheus-community/helm-charts/pull/2839"
+    - kind: changed
+      description: "fix Chart.yaml - remove engine: gotpl"
+      links:
+        - name: GitHub PR
+          url: https://github.com/prometheus-community/helm-charts/pull/2814
+    - kind: changed
+      description: "Update grafana chart version"
+      links:
+        - name: GitHUb PR
+          url: https://github.com/prometheus-community/helm-charts/pull/2805
+    - kind: changed
+      description: "Upgrade to 43.0.0"
+      links:
+        - name: GitHub PR
+          url: https://github.com/prometheus-community/helm-charts/pull/2789
+    - kind: changed
+      description: "Bump Grafana Chart to most recent commit"
+      links:
+        - name: GitHub PR
+          url: https://github.com/prometheus-community/helm-charts/pull/2801
+    - kind: changed
+      description: "Fix netpol to allow access to the api-server"
+      links:
+        - name: GitHub PR
+          url: https://github.com/prometheus-community/helm-charts/pull/2790
+    - kind: changed
+      description: "bump grafana chart dependency to 6.45.0 and node-exporter to 4.8.0"
+      links:
+        - name: GitHub PR
+          url: https://github.com/prometheus-community/helm-charts/pull/2773
+    - kind: changed
+      description: "Allow setting timeoutSeconds in ValidatingWebhook"
+      links:
+        - name: GitHub PR
+          url: https://github.com/prometheus-community/helm-charts/pull/2761

--- a/charts/infra-apps/README.md
+++ b/charts/infra-apps/README.md
@@ -1,6 +1,6 @@
 # infra-apps
 
-![Version: 0.139.1](https://img.shields.io/badge/Version-0.139.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.140.0](https://img.shields.io/badge/Version-0.140.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Argo CD app-of-apps config for infrastructure components
 
@@ -78,7 +78,7 @@ This chart is maintained by [Adfinis](https://adfinis.com/?pk_campaign=github&pk
 | kubePrometheusStack.destination.namespace | string | `"infra-monitoring"` | Namespace |
 | kubePrometheusStack.enabled | bool | `false` | Enable prometheus-operator |
 | kubePrometheusStack.repoURL | string | [repo](https://prometheus-community.github.io/helm-charts) | Repo URL |
-| kubePrometheusStack.targetRevision | string | `"42.1.0"` | [kube-prometheus-stack Helm chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack) version |
+| kubePrometheusStack.targetRevision | string | `"44.2.1"` | [kube-prometheus-stack Helm chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack) version |
 | kubePrometheusStack.values | object | [upstream values](https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/values.yaml) | Helm values |
 | kured | object | [example](./examples/kured.yaml) | [kured](https://github.com/kubereboot/kured) |
 | kured.annotations | object | `{}` | Annotations for Kured app |

--- a/charts/infra-apps/values.yaml
+++ b/charts/infra-apps/values.yaml
@@ -133,7 +133,7 @@ kubePrometheusStack:
   # -- Chart
   chart: kube-prometheus-stack
   # -- [kube-prometheus-stack Helm chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack) version
-  targetRevision: 42.1.0
+  targetRevision: 44.2.1
   # -- Helm values
   # @default -- [upstream values](https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/values.yaml)
   values: {}


### PR DESCRIPTION
<!--
    Thank you for your contribution. Please use this template to help guide
    you towards preparing a PR that fullfills our merge requirements.
-->
# Description

This version upgrades Prometheus-Operator to v0.62.0, Prometheus to v2.41.0 and Thanos to v0.30.1.

Run these commands to update the CRDs before applying the upgrade.

```console
kubectl apply --server-side -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.62.0/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml
kubectl apply --server-side -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.62.0/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
kubectl apply --server-side -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.62.0/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml
kubectl apply --server-side -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.62.0/example/prometheus-operator-crd/monitoring.coreos.com_probes.yaml
kubectl apply --server-side -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.62.0/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
kubectl apply --server-side -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.62.0/example/prometheus-operator-crd/monitoring.coreos.com_prometheusrules.yaml
kubectl apply --server-side -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.62.0/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
kubectl apply --server-side -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.62.0/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
```

If you have explicitly set `prometheusOperator.admissionWebhooks.failurePolicy`, this value is now always used even when `.prometheusOperator.admissionWebhooks.patch.enabled` is `true` (the default).

The values for `prometheusOperator.image.tag` & `prometheusOperator.prometheusConfigReloader.image.tag` are now empty by default and the Chart.yaml `appVersion` field is used instead.

# Issues

<!--
    Link related issues here, it's ok if this is empty but we do recommend that
    you create issues before working on PRs, issues on internal trackers are
    fine and need not be linked here.
-->

# Checklist

<!--
    Take care of the default items before marking your PR as ready for review,
    be prepared to add more items.
-->

* [x] This PR contains a description of the changes I'm making
* [x] I updated the version in Chart.yaml
* [x] I updated the changelog according to the `artifacthub.io/changes` annotation in the Chart.yaml. See following [example](https://github.com/adfinis/helm-charts/pull/858/files).
* [x] I updated applicable README.md files using  `pre-commit run`
* [x] I documented any high-level concepts I'm introducing in `docs/`
* [x] CI is currently green and this is ready for review
* [x] I am ready to test changes after they are applied and released

<!--
    Please open PRs as Draft while you make CI green and/or finalise
    documentation. Your PR will be assigned to a CODEOWNER once you mark it
    as "Ready for Review".

   Once it is approved we will squash your changes onto the default branch
   and our trusty bot account will release them to the repository.
-->
