### PR TITLE
chore: add dev-devops group to CODEOWNERS for timed and osschallenge charts

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -13,3 +13,5 @@
 /charts/vault-auth                  @adfinis/helm-charts @eyenx
 /charts/vault-monitoring            @adfinis/helm-charts @pree @eyenx
 /charts/mopsos                      @adfinis/helm-charts @hairmare @eyenx
+/charts/timed                       @adfinis/helm-charts @adfinis/dev-devops
+/charts/osschallenge                @adfinis/helm-charts @adfinis/dev-devops


### PR DESCRIPTION
<!--
    Thank you for your contribution. Please use this template to help guide
    you towards preparing a PR that fullfills our merge requirements.
-->
# Description

Make GitHub assign members of the newly created dev-devops team for review on timed and osschallenge Helm charts.

# Issues

<!--
    Link related issues here, it's ok if this is empty but we do recommend that
    you create issues before working on PRs, issues on internal trackers are
    fine and need not be linked here.
-->

# Checklist

<!--
    Take care of the default items before marking your PR as ready for review,
    be prepared to add more items.
-->

* [x] This PR contains a description of the changes I'm making
* [x] I updated the version in Chart.yaml
* [x] I updated the changelog with an `artifacthub.io/changes` annotation in `Chart.yaml`, check the [example](docs/development.md#Changelog) in the documentation.
* [x] I updated applicable README.md files using  `pre-commit run`
* [x] I documented any high-level concepts I'm introducing in `docs/`
* [x] CI is currently green and this is ready for review
* [x] I am ready to test changes after they are applied and released

<!--
    Please open PRs as Draft while you make CI green and/or finalise
    documentation. Your PR will be assigned to a CODEOWNER once you mark it
    as "Ready for Review".

   Once it is approved we will squash your changes onto the default branch
   and our trusty bot account will release them to the repository.
-->
