### PR TITLE
chore(storage-apps): update ceph-csi to 3.8.0

### DIFF
--- a/charts/storage-apps/Chart.yaml
+++ b/charts/storage-apps/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: storage-apps
 description: Argo CD app-of-apps config for storage applications
 type: application
-version: 0.12.0
+version: 0.13.0
 home: https://github.com/adfinis/helm-charts/tree/main/charts/storage-apps
 sources:
   - https://github.com/adfinis/helm-charts
@@ -17,12 +17,7 @@ dependencies:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "Update minio from 5.0.0 to 5.0.1"
+      description: "Update ceph-csi from 3.7.* to 3.8.0"
       links:
-        - name: Bump MinIO version to RELEASE.2022-11-11T03-44-20Z
-          url: https://github.com/minio/minio/commit/f7db12c7effaca8410d6f11a7edd76d338e11ba0
-    - kind: changed
-      description: "Update minio from 4.1.0 to 5.0.0"
-      links:
-        - name: Remove gateway completely
-          url: https://github.com/minio/minio/commit/23b329b9df262246c7ce7f76daf7efaf732b6e5f
+        - name: Ceph-CSI v3.8.0 Release
+          url: https://github.com/ceph/ceph-csi/releases/tag/v3.8.0

--- a/charts/storage-apps/README.md
+++ b/charts/storage-apps/README.md
@@ -1,6 +1,6 @@
 # storage-apps
 
-![Version: 0.12.0](https://img.shields.io/badge/Version-0.12.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.13.0](https://img.shields.io/badge/Version-0.13.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Argo CD app-of-apps config for storage applications
 
@@ -28,14 +28,14 @@ This chart is maintained by [Adfinis](https://adfinis.com/?pk_campaign=github&pk
 | cephCsiCephfs.destination.namespace | string | `"infra-storage"` | Namespace |
 | cephCsiCephfs.enabled | bool | `false` | Enable ceph-csi-cephfs |
 | cephCsiCephfs.repoURL | string | [repo](https://ceph.github.io/csi-charts) | Repo URL |
-| cephCsiCephfs.targetRevision | string | `"3.7.*"` | [ceph-csi-cephfs Helm chart](https://github.com/ceph/csi-charts/tree/master/docs/cephfs) version |
+| cephCsiCephfs.targetRevision | string | `"3.8.0"` | [ceph-csi-cephfs Helm chart](https://github.com/ceph/csi-charts/tree/master/docs/cephfs) version |
 | cephCsiCephfs.values | object | [upstream values](https://github.com/ceph/csi-charts/tree/master/docs/cephfs/ceph-csi-cephfs/values.yaml) | Helm values |
 | cephCsiRbd | object | - | [ceph-csi-rbd](https://github.com/ceph/ceph-csi/) |
 | cephCsiRbd.chart | string | `"ceph-csi-rbd"` | Chart |
 | cephCsiRbd.destination.namespace | string | `"infra-storage"` | Namespace |
 | cephCsiRbd.enabled | bool | `false` | Enable ceph-csi-rbd |
 | cephCsiRbd.repoURL | string | [repo](https://ceph.github.io/csi-charts) | Repo URL |
-| cephCsiRbd.targetRevision | string | `"3.7.*"` | [ceph-csi-rbd Helm chart](https://github.com/ceph/csi-charts/tree/master/docs/rbd) version |
+| cephCsiRbd.targetRevision | string | `"3.8.0"` | [ceph-csi-rbd Helm chart](https://github.com/ceph/csi-charts/tree/master/docs/rbd) version |
 | cephCsiRbd.values | object | [upstream values](https://github.com/ceph/csi-charts/tree/master/docs/rbd/ceph-csi-rbd/values.yaml) | Helm values |
 | csiDriverSmb | object | [example](./examples/csi-driver-smb.yaml) | [csi-driver-smb](https://github.com/kubernetes-csi/csi-driver-smb) |
 | csiDriverSmb.chart | string | `"csi-driver-smb"` | Chart |

--- a/charts/storage-apps/values.yaml
+++ b/charts/storage-apps/values.yaml
@@ -13,7 +13,7 @@ cephCsiRbd:
   # -- Chart
   chart: "ceph-csi-rbd"
   # -- [ceph-csi-rbd Helm chart](https://github.com/ceph/csi-charts/tree/master/docs/rbd) version
-  targetRevision: "3.7.*"
+  targetRevision: "3.8.0"
   # -- Helm values
   # @default -- [upstream values](https://github.com/ceph/csi-charts/tree/master/docs/rbd/ceph-csi-rbd/values.yaml)
   values: {}
@@ -33,7 +33,7 @@ cephCsiCephfs:
   # -- Chart
   chart: "ceph-csi-cephfs"
   # -- [ceph-csi-cephfs Helm chart](https://github.com/ceph/csi-charts/tree/master/docs/cephfs) version
-  targetRevision: "3.7.*"
+  targetRevision: "3.8.0"
   # -- Helm values
   # @default -- [upstream values](https://github.com/ceph/csi-charts/tree/master/docs/cephfs/ceph-csi-cephfs/values.yaml)
   values: {}


### PR DESCRIPTION
# Description

Update ceph-csi in storage-apps to 3.8.0

This release provides the following new features:
- fscrypt support for [RBD](https://github.com/ceph/ceph-csi/pull/3310) and [CephFS](https://github.com/ceph/ceph-csi/pull/3460)

A potential issue for one of our customers, which is still running Octopus could be that ceph-csi is following the upstream support for Ceph releases and because of that they officially removed support for Octopus in this release of ceph-csi. As this is the only customer were we're using ceph-csi we could also potentially remove it from storage-apps?

# Checklist

* [x] This PR contains a description of the changes I'm making
* [x] I updated the version in Chart.yaml
* [x] I updated the changelog with an `artifacthub.io/changes` annotation in `Chart.yaml`, check the [example](docs/development.md#Changelog) in the documentation.
* [x] I updated applicable README.md files using  `pre-commit run`
* [x] I documented any high-level concepts I'm introducing in `docs/`
* [x] CI is currently green and this is ready for review
* [x] I am ready to test changes after they are applied and released
