### PR TITLE
feat(tracing-apps): update jaeger-operator from 1.39.0 to 1.42.0

### DIFF
--- a/charts/tracing-apps/Chart.yaml
+++ b/charts/tracing-apps/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: tracing-apps
 description: Argo CD app-of-apps config for tracing applications
 type: application
-version: 0.21.0
+version: 0.22.0
 home: https://github.com/adfinis/helm-charts/tree/main/charts/tracing-apps
 sources:
   - https://github.com/adfinis/helm-charts
@@ -18,26 +18,18 @@ annotations:
   artifacthub.io/changes: |
     - kind: changed
       description: |
-        otel-collector: update from 0.70.0 to 0.72.0
+        jaeger-operator: Update from 1.39.0 to 1.42.0
 
-        Removes a bunch of deprecated feature gates and adds several features
-        like exponential backoff handling, a new `connectors` pipeline component
-        for merging existing piplines and more.
+        Introduces official support for K8s 1.24.
       links:
-        - name: GitHub Release 0.71.0
-          url: https://github.com/open-telemetry/opentelemetry-collector/releases/tag/cmd%2Fbuilder%2Fv0.72.0
-        - name: GitHub Release 0.72.0
-          url: https://github.com/open-telemetry/opentelemetry-collector/releases/tag/cmd%2Fbuilder%2Fv0.72.0
+        - name: Changelog for 1.40.0
+          url: https://github.com/jaegertracing/jaeger-operator/blob/main/CHANGELOG.md#1400-2022-12-23
+        - name: Changelog for 1.41.1
+          url: https://github.com/jaegertracing/jaeger-operator/blob/main/CHANGELOG.md#1411-2023-01-23
     - kind: changed
-      description: 'otel-collector: update chart from 0.47.0 to 0.49.1'
+      description: 'jaeger-operator: update chart from 2.39.0 to 2.41.0'
       links:
-        - name: 'feat: bump otel-collector from 0.71.0 to 0.72.0'
-          url: https://github.com/open-telemetry/opentelemetry-helm-charts/pull/655
-        - name: 'feat: Support loadBalancerSourceRanges in service spec'
-          url: https://github.com/open-telemetry/opentelemetry-helm-charts/pull/647
-        - name: 'feat: Add "ExporterDroppedSpans" PrometheusRule for spans that failed to be exported'
-          url: https://github.com/open-telemetry/opentelemetry-helm-charts/pull/633
-        - name: 'fix: Allows for configuration of revisionHistoryLimit'
-          url: https://github.com/open-telemetry/opentelemetry-helm-charts/pull/631
-        - name: 'feat: expose topologySpreadConstraints'
-          url: https://github.com/open-telemetry/opentelemetry-helm-charts/pull/622
+        - name: 'feat: update jaeger-operator from 1.39.0 to 1.42.0'
+          url: https://github.com/jaegertracing/helm-charts/pull/458
+        - name: 'feat: allow setting the Certificate Issuer kind'
+          url: https://github.com/jaegertracing/helm-charts/pull/446

--- a/charts/tracing-apps/README.md
+++ b/charts/tracing-apps/README.md
@@ -1,6 +1,6 @@
 # tracing-apps
 
-![Version: 0.21.0](https://img.shields.io/badge/Version-0.21.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.22.0](https://img.shields.io/badge/Version-0.22.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Argo CD app-of-apps config for tracing applications
 
@@ -28,7 +28,7 @@ This chart is maintained by [Adfinis](https://adfinis.com/?pk_campaign=github&pk
 | jaegerOperator.destination.namespace | string | `"infra-jaeger"` | Namespace |
 | jaegerOperator.enabled | bool | `false` | Enable jaeger-operator |
 | jaegerOperator.repoURL | string | [repo](https://jaegertracing.github.io/helm-charts) | Repo URL |
-| jaegerOperator.targetRevision | string | `"2.39.0"` | [jaeger-operator Helm chart](https://github.com/jaegertracing/helm-charts/tree/main/charts/jaeger-operator) |
+| jaegerOperator.targetRevision | string | `"2.41.0"` | [jaeger-operator Helm chart](https://github.com/jaegertracing/helm-charts/tree/main/charts/jaeger-operator) |
 | jaegerOperator.values | object | [upstream values](https://github.com/jaegertracing/helm-charts/blob/main/charts/jaeger-operator/values.yaml) | Helm values |
 | opentelemetryCollector | object | - | [opentelemetry-collector](https://opentelemetry.io/docs/collector/) ([example](./examples/opentelemetryCollector.yaml)) |
 | opentelemetryCollector.chart | string | `"opentelemetry-collector"` | Chart |

--- a/charts/tracing-apps/values.yaml
+++ b/charts/tracing-apps/values.yaml
@@ -13,7 +13,7 @@ jaegerOperator:
   # -- Chart
   chart: "jaeger-operator"
   # -- [jaeger-operator Helm chart](https://github.com/jaegertracing/helm-charts/tree/main/charts/jaeger-operator)
-  targetRevision: "2.39.0"
+  targetRevision: "2.41.0"
   # -- Helm values
   # @default -- [upstream values](https://github.com/jaegertracing/helm-charts/blob/main/charts/jaeger-operator/values.yaml)
   values: {}


### PR DESCRIPTION
<!--
    Thank you for your contribution. Please use this template to help guide
    you towards preparing a PR that fullfills our merge requirements.
-->
# Description

Mainly adds official 2.24 support by bumping the operator after the chart having missed a couple of version bumps.

# Issues

<!--
    Link related issues here, it's ok if this is empty but we do recommend that
    you create issues before working on PRs, issues on internal trackers are
    fine and need not be linked here.

    If your PR adds a new chart we expect you to create and link an issue so we
    can discuss adding your chart before you put the work into creating it.
-->

# Checklist

<!--
    Take care of the default items before marking your PR as ready for review,
    be prepared to add more items.
-->

* [x] This PR contains a description of the changes I'm making
* [x] I updated the version in Chart.yaml
* [x] I updated the changelog with an `artifacthub.io/changes` annotation in `Chart.yaml`, check the [example](docs/development.md#Changelog) in the documentation.
* [x] I updated applicable README.md files using  `pre-commit run`
* [x] I documented any high-level concepts I'm introducing in `docs/`
* [x] CI is currently green and this is ready for review
* [x] I am ready to test changes after they are applied and released

<!--
    Please open PRs as Draft while you make CI green and/or finalise
    documentation. Your PR will be assigned to a CODEOWNER once you mark it
    as "Ready for Review".

   Once it is approved we will squash your changes onto the default branch
   and our trusty bot account will release them to the repository.
-->
