### PR TITLE
feat(infra-apps): update kube-prometheus-stack from 44.3.0 to 45.9.1

### DIFF
--- a/charts/infra-apps/Chart.yaml
+++ b/charts/infra-apps/Chart.yaml
@@ -18,7 +18,7 @@ annotations:
   artifacthub.io/changes: |
     - kind: changed
       description: |
-        kube-prometheus-stack: update from 0.62.0 to 0.62.0
+        kube-prometheus-stack: update from 0.62.0 to 0.63.0
 
         This version upgrades Prometheus-Operator to v0.63.0, Prometheus to v2.43.0, and Thanos to v0.30.2.
       links:
@@ -29,7 +29,7 @@ annotations:
         - name: GitHub Release Thanos v0.30.2
           url: https://github.com/thanos-io/thanos/releases/tag/v0.30.2
     - kind: changed
-      description: "kube-prometheus-stack: update chart from 44.3.0 to 45.9.0"
+      description: "kube-prometheus-stack: update chart from 44.3.0 to 45.9.1"
       links:
         - name: "Additional labels for ServiceMonitors"
           url: https://github.com/prometheus-community/helm-charts/pull/3132
@@ -65,3 +65,5 @@ annotations:
           url: https://github.com/prometheus-community/helm-charts/pull/2993
         - name: "Fix registry for Config Reloader and Thanos"
           url: https://github.com/prometheus-community/helm-charts/pull/2975
+        - name: "Fix deployment when thanos field is set to null"
+          url: https://github.com/prometheus-community/helm-charts/pull/3163

--- a/charts/infra-apps/Chart.yaml
+++ b/charts/infra-apps/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: infra-apps
 description: Argo CD app-of-apps config for infrastructure components
 type: application
-version: 0.153.0
+version: 0.154.0
 home: https://github.com/adfinis/helm-charts/tree/main/charts/infra-apps
 sources:
   - https://github.com/adfinis/helm-charts
@@ -18,16 +18,50 @@ annotations:
   artifacthub.io/changes: |
     - kind: changed
       description: |
-        nginx-ingress: update from 1.6.4 to 1.7.0
+        kube-prometheus-stack: update from 0.62.0 to 0.62.0
 
-        - Upgrade alpine 3.17.2
-        - Upgrade golang 1.20
-        - Drop testing/support for Kubernetes 1.23
+        This version upgrades Prometheus-Operator to v0.63.0, Prometheus to v2.43.0, and Thanos to v0.30.2.
       links:
-        - name: GitHub Release
-          url: https://github.com/kubernetes/ingress-nginx/releases/tag/controller-v1.7.0
+        - name: GitHub Release Prometheus-Operator v0.64.0
+          url: https://github.com/prometheus-operator/prometheus-operator/releases/tag/v0.64.0
+        - name: GitHub Release Prometheus v2.43.0
+          url: https://github.com/prometheus/prometheus/releases/tag/v2.43.0
+        - name: GitHub Release Thanos v0.30.2
+          url: https://github.com/thanos-io/thanos/releases/tag/v0.30.2
     - kind: changed
-      description: "ngin-ingress update chart from 4.5.2 to 4.6.0"
+      description: "kube-prometheus-stack: update chart from 44.3.0 to 45.9.0"
       links:
-        - name: "update chart for 1.7.0"
-          url: https://github.com/kubernetes/ingress-nginx/pull/9784
+        - name: "Additional labels for ServiceMonitors"
+          url: https://github.com/prometheus-community/helm-charts/pull/3132
+        - name: "Import Node Exporter / MacOS grafana dashboard conditionally"
+          url: https://github.com/prometheus-community/helm-charts/pull/3054
+        - name: "Allow out_of_order_time_window in Prometheus spec"
+          url: https://github.com/prometheus-community/helm-charts/pull/2960
+        - name: "add EndpointSlices for operator to support K8s 1.22+"
+          url: https://github.com/prometheus-community/helm-charts/pull/2948
+        - name: "bump kube-state-metrics chart to fix global.imageRegistry usage"
+          url: https://github.com/prometheus-community/helm-charts/pull/3107
+        - name: "Enable network policy for prometheus"
+          url: https://github.com/prometheus-community/helm-charts/pull/2997
+        - name: "Update grafana chart from 6.50.* to 6.51.*"
+          url: https://github.com/prometheus-community/helm-charts/pull/3086
+        - name: "Update dependencies to versions which support local container registry"
+          url: https://github.com/prometheus-community/helm-charts/pull/3059
+        - name: "Update kube-webhook-certgen from v1.3.0 to v20221220-controller-v1.5.1-58-g787ea74b6"
+          url: https://github.com/prometheus-community/helm-charts/pull/3061
+        - name: "Update kube-state-metrics from 4.24.* to 4.30.*"
+          url: https://github.com/prometheus-community/helm-charts/pull/3046
+        - name: "Add permission to the alertmanagers/status resource"
+          url: https://github.com/prometheus-community/helm-charts/pull/3016
+        - name: "Add stringConfig for alertmanager"
+          url: https://github.com/prometheus-community/helm-charts/pull/2992
+        - name: "Fixes deployment of Thanos Ruler - Addresses Default Thanos Ruler name too long"
+          url: https://github.com/prometheus-community/helm-charts/pull/3021
+        - name: "Update from v0.62.0 to v0.63.0"
+          url: https://github.com/prometheus-community/helm-charts/pull/3012
+        - name: "Update helm Chart.lock to get latest grafana version"
+          url: https://github.com/prometheus-community/helm-charts/pull/2990
+        - name: "Support multi-cluster alerting rules for prometheus-operator"
+          url: https://github.com/prometheus-community/helm-charts/pull/2993
+        - name: "Fix registry for Config Reloader and Thanos"
+          url: https://github.com/prometheus-community/helm-charts/pull/2975

--- a/charts/infra-apps/README.md
+++ b/charts/infra-apps/README.md
@@ -1,6 +1,6 @@
 # infra-apps
 
-![Version: 0.153.0](https://img.shields.io/badge/Version-0.153.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.154.0](https://img.shields.io/badge/Version-0.154.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Argo CD app-of-apps config for infrastructure components
 
@@ -78,7 +78,7 @@ This chart is maintained by [Adfinis](https://adfinis.com/?pk_campaign=github&pk
 | kubePrometheusStack.destination.namespace | string | `"infra-monitoring"` | Namespace |
 | kubePrometheusStack.enabled | bool | `false` | Enable prometheus-operator |
 | kubePrometheusStack.repoURL | string | [repo](https://prometheus-community.github.io/helm-charts) | Repo URL |
-| kubePrometheusStack.targetRevision | string | `"44.3.0"` | [kube-prometheus-stack Helm chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack) version |
+| kubePrometheusStack.targetRevision | string | `"45.9.0"` | [kube-prometheus-stack Helm chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack) version |
 | kubePrometheusStack.values | object | [upstream values](https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/values.yaml) | Helm values |
 | kured | object | [example](./examples/kured.yaml) | [kured](https://github.com/kubereboot/kured) |
 | kured.annotations | object | `{}` | Annotations for Kured app |

--- a/charts/infra-apps/README.md
+++ b/charts/infra-apps/README.md
@@ -78,7 +78,7 @@ This chart is maintained by [Adfinis](https://adfinis.com/?pk_campaign=github&pk
 | kubePrometheusStack.destination.namespace | string | `"infra-monitoring"` | Namespace |
 | kubePrometheusStack.enabled | bool | `false` | Enable prometheus-operator |
 | kubePrometheusStack.repoURL | string | [repo](https://prometheus-community.github.io/helm-charts) | Repo URL |
-| kubePrometheusStack.targetRevision | string | `"45.9.0"` | [kube-prometheus-stack Helm chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack) version |
+| kubePrometheusStack.targetRevision | string | `"45.9.1"` | [kube-prometheus-stack Helm chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack) version |
 | kubePrometheusStack.values | object | [upstream values](https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/values.yaml) | Helm values |
 | kured | object | [example](./examples/kured.yaml) | [kured](https://github.com/kubereboot/kured) |
 | kured.annotations | object | `{}` | Annotations for Kured app |

--- a/charts/infra-apps/values.yaml
+++ b/charts/infra-apps/values.yaml
@@ -133,7 +133,7 @@ kubePrometheusStack:
   # -- Chart
   chart: kube-prometheus-stack
   # -- [kube-prometheus-stack Helm chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack) version
-  targetRevision: 44.3.0
+  targetRevision: 45.9.0
   # -- Helm values
   # @default -- [upstream values](https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/values.yaml)
   values: {}

--- a/charts/infra-apps/values.yaml
+++ b/charts/infra-apps/values.yaml
@@ -133,7 +133,7 @@ kubePrometheusStack:
   # -- Chart
   chart: kube-prometheus-stack
   # -- [kube-prometheus-stack Helm chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack) version
-  targetRevision: 45.9.0
+  targetRevision: 45.9.1
   # -- Helm values
   # @default -- [upstream values](https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/values.yaml)
   values: {}


### PR DESCRIPTION
# Description

<!-- Describe the changes your PR introduces here. -->
Upgrades Prometheus-Operator to v0.63.0, Prometheus to v2.43.0 and Thanos to v0.30.2.

The main feature is alpha support for the new `PrometheusAgent` CRD + a  bunch of bugfixes and updates to several bundled components.

# Issues

<!--
    Link related issues here, it's ok if this is empty but we do recommend that
    you create issues before working on PRs, issues on internal trackers are
    fine and need not be linked here.

    If your PR adds a new chart we expect you to create and link an issue so we
    can discuss adding your chart before you put the work into creating it.
-->

# Checklist

<!--
    Take care of the default items before marking your PR as ready for review,
    be prepared to add more items.
-->

* [x] This PR contains a description of the changes I'm making
* [x] I updated the version in Chart.yaml
* [x] I updated the changelog with an `artifacthub.io/changes` annotation in `Chart.yaml`, check the [example](docs/development.md#Changelog) in the documentation.
* [x] I updated applicable README.md files using  `pre-commit run`
* [x] I documented any high-level concepts I'm introducing in `docs/`
* [x] CI is currently green and this is ready for review
* [x] I am ready to test changes after they are applied and released

<!--
    Please open PRs as Draft while you make CI green and/or finalise
    documentation. Your PR will be assigned to a CODEOWNER once you mark it
    as "Ready for Review".

   Once it is approved we will squash your changes onto the default branch
   and our trusty bot account will release them to the repository.
-->
