### PR TITLE
feat(security-apps): update oauth2-proxy chart from 6.5.0 to 6.10.1

### DIFF
--- a/charts/security-apps/Chart.yaml
+++ b/charts/security-apps/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: security-apps
 description: Argo CD app-of-apps config for security applications
 type: application
-version: 0.72.0
+version: 0.73.0
 home: https://github.com/adfinis/helm-charts/tree/main/charts/security-apps
 sources:
   - https://github.com/adfinis/helm-charts
@@ -17,28 +17,15 @@ dependencies:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: |
-        neuvector: update from 5.1.0 to 5.1.2
-
-        * Support cri-o 1.26+ and OpenShift 4.11+
-        * Enable auto scan in configMap
-        * improve controller and enforcer CPU and memory consumption
-        * fix various ui issues
-        * Make gravatar optional
-        * Hostname based egress network policy
-        * Display cluster namespace resource in UI
-        * Various performance and scalability improvements
+      description: "oauth2-proxy: update chart from 6.5.0 to 6.10.1"
       links:
-        - name: GitHub Release 5.1.2
-          url: https://github.com/neuvector/neuvector/releases/tag/v5.1.2
-        - name: GitHub Release 5.1.1
-          url: https://github.com/neuvector/neuvector/releases/tag/v5.1.1
-    - kind: changed
-      description: "neuvector: update charts from 2.4.0 to 2.4.3"
-      links:
-        - name: "fix: update to 5.1.2"
-          url: https://github.com/neuvector/neuvector-helm/pull/240
-        - name: "fix: update to 5.1.1"
-          url: https://github.com/neuvector/neuvector-helm/pull/225
-        - name: "chore: bump chart to 2.4.1"
-          url: https://github.com/neuvector/neuvector-helm/commit/0f3d7243c31003034e2cf2231e6163baaaef3626
+        - name: "feat: revisionHistoryLimit to the chart"
+          url: https://github.com/oauth2-proxy/manifests/pull/137
+        - name: "fix: convert bool to string before passing to helm templating engine"
+          url: https://github.com/oauth2-proxy/manifests/pull/134
+        - name: "feat: Pass oauth2-proxy config through helm templating"
+          url: https://github.com/oauth2-proxy/manifests/pull/132
+        - name: "feat: Use google workload identity"
+          url: https://github.com/oauth2-proxy/manifests/pull/127
+        - name: "feat: extraArgs as a list"
+          url: https://github.com/oauth2-proxy/manifests/pull/124

--- a/charts/security-apps/README.md
+++ b/charts/security-apps/README.md
@@ -1,6 +1,6 @@
 # security-apps
 
-![Version: 0.72.0](https://img.shields.io/badge/Version-0.72.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.73.0](https://img.shields.io/badge/Version-0.73.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Argo CD app-of-apps config for security applications
 
@@ -86,7 +86,7 @@ This chart is maintained by [Adfinis](https://adfinis.com/?pk_campaign=github&pk
 | oauth2Proxy.destination.namespace | string | `"infra-oauth2-proxy"` | Namespace |
 | oauth2Proxy.enabled | bool | `false` | Enable oauth2-proxy |
 | oauth2Proxy.repoURL | string | [repo](https://https://oauth2-proxy.github.io/manifests) | Repo URL |
-| oauth2Proxy.targetRevision | string | `"6.5.0"` | [oauth2-proxy Helm chart](https://github.com/oauth2-proxy/manifests/tree/main/helm/oauth2-proxy) |
+| oauth2Proxy.targetRevision | string | `"6.10.1"` | [oauth2-proxy Helm chart](https://github.com/oauth2-proxy/manifests/tree/main/helm/oauth2-proxy) |
 | oauth2Proxy.values | object | [upstream values](https://github.com/oauth2-proxy/manifests/blob/main/helm/oauth2-proxy/values.yaml) | Helm values |
 | secretsStoreCsiDriver | object | - | [secrets-store-csi-driver](https://github.com/kubernetes-sigs/secrets-store-csi-driver) ([example](./examples/secrets-store-csi-driver.yaml)) |
 | secretsStoreCsiDriver.chart | string | `"secrets-store-csi-driver"` | Chart |

--- a/charts/security-apps/values.yaml
+++ b/charts/security-apps/values.yaml
@@ -283,7 +283,7 @@ oauth2Proxy:
   # -- Chart
   chart: oauth2-proxy
   # -- [oauth2-proxy Helm chart](https://github.com/oauth2-proxy/manifests/tree/main/helm/oauth2-proxy)
-  targetRevision: 6.5.0
+  targetRevision: 6.10.1
   # -- Helm values
   # @default -- [upstream values](https://github.com/oauth2-proxy/manifests/blob/main/helm/oauth2-proxy/values.yaml)
   values: {}


### PR DESCRIPTION
# Description

Adds a bunch of features to the chart, starts supporting workload identities on google, and allows templating the oauth2-proxy config through helm templating.

# Issues

<!--
    Link related issues here, it's ok if this is empty but we do recommend that
    you create issues before working on PRs, issues on internal trackers are
    fine and need not be linked here.

    If your PR adds a new chart we expect you to create and link an issue so we
    can discuss adding your chart before you put the work into creating it.
-->

# Checklist

<!--
    Take care of the default items before marking your PR as ready for review,
    be prepared to add more items.
-->

* [x] This PR contains a description of the changes I'm making
* [x] I updated the version in Chart.yaml
* [x] I updated the changelog with an `artifacthub.io/changes` annotation in `Chart.yaml`, check the [example](docs/development.md#Changelog) in the documentation.
* [x] I updated applicable README.md files using  `pre-commit run`
* [x] I documented any high-level concepts I'm introducing in `docs/`
* [x] CI is currently green and this is ready for review
* [x] I am ready to test changes after they are applied and released

<!--
    Please open PRs as Draft while you make CI green and/or finalise
    documentation. Your PR will be assigned to a CODEOWNER once you mark it
    as "Ready for Review".

   Once it is approved we will squash your changes onto the default branch
   and our trusty bot account will release them to the repository.
-->
