### PR TITLE
fix(ci): move to new (old) home of helm-unittest and get rid of helm2 support

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,7 +21,7 @@ jobs:
     - name: install helm unittest
       run: |
         helm env
-        helm plugin install https://github.com/quintush/helm-unittest
+        helm plugin install https://github.com/helm-unittest/helm-unittest
 
     - uses: actions/setup-python@v4
       with:

--- a/docs/development.md
+++ b/docs/development.md
@@ -110,12 +110,12 @@ tests:
       # add more assertions here!
       - matchSnapshots: {}
 ```
-Details on the available assertions may be found in the [docs](https://github.com/quintush/helm-unittest/blob/master/DOCUMENT.md).
+Details on the available assertions may be found in the [docs](https://github.com/helm-unittest/helm-unittest/blob/main/DOCUMENT.md).
 
 After creating a test you should run it to ensure that it is green.
 
 ```bash
-helm unittest --helm3 charts/infra-apps
+helm unittest charts/infra-apps
 ```
 
 When you create tests that contain `matchSnapshots` the tool will create and populate a
@@ -123,7 +123,7 @@ When you create tests that contain `matchSnapshots` the tool will create and pop
 snapshots.
 
 ```bash
-helm unittest --helm3 --update-snapshot charts/infra-apps
+helm unittest --update-snapshot charts/infra-apps
 ```
 
 Keep in mind that, if you choose to add snapshots that contain versions, you

--- a/hack/chart-testing/ct.yaml
+++ b/hack/chart-testing/ct.yaml
@@ -5,6 +5,6 @@ chart-repos:
   - secrets-store-csi-driver=https://kubernetes-sigs.github.io/secrets-store-csi-driver/charts
   - grafana=https://grafana.github.io/helm-charts
 additional-commands:
-  - helm unittest --helm3 --color {{ .Path }}
+  - helm unittest --color {{ .Path }}
   - .tmp/bin/ah lint -p {{ .Path }}
   - hack/pluto.sh {{ .Path }}

--- a/hack/update-snapshots.sh
+++ b/hack/update-snapshots.sh
@@ -24,5 +24,5 @@ charts=`printf '%s\n' ${charts[@]} | sort -u`
 for chart in $charts; do
     # unittest needs deps to work
     helm dep build $chart
-    helm unittest --helm3 --update-snapshot $chart
+    helm unittest --update-snapshot $chart
 done


### PR DESCRIPTION
# Description

Gets rid of the no `--helm3` arg error.

# Issues

<!--
    Link related issues here, it's ok if this is empty but we do recommend that
    you create issues before working on PRs, issues on internal trackers are
    fine and need not be linked here.

    If your PR adds a new chart we expect you to create and link an issue so we
    can discuss adding your chart before you put the work into creating it.
-->
* https://github.com/quintush/helm-unittest/issues/124

# Checklist

<!--
    Take care of the default items before marking your PR as ready for review,
    be prepared to add more items.
-->

* [x] This PR contains a description of the changes I'm making
* [x] I updated the version in Chart.yaml
* [x] I updated the changelog with an `artifacthub.io/changes` annotation in `Chart.yaml`, check the [example](docs/development.md#Changelog) in the documentation.
* [x] I updated applicable README.md files using  `pre-commit run`
* [x] I documented any high-level concepts I'm introducing in `docs/`
* [x] CI is currently green and this is ready for review
* [x] I am ready to test changes after they are applied and released

<!--
    Please open PRs as Draft while you make CI green and/or finalise
    documentation. Your PR will be assigned to a CODEOWNER once you mark it
    as "Ready for Review".

   Once it is approved we will squash your changes onto the default branch
   and our trusty bot account will release them to the repository.
-->
