### PR TITLE
feat(infra-apps): update cert-manager from 1.11.1 to 1.12.0

### DIFF
--- a/charts/infra-apps/Chart.yaml
+++ b/charts/infra-apps/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: infra-apps
 description: Argo CD app-of-apps config for infrastructure components
 type: application
-version: 0.160.0
+version: 0.161.0
 home: https://github.com/adfinis/helm-charts/tree/main/charts/infra-apps
 sources:
   - https://github.com/adfinis/helm-charts
@@ -17,7 +17,14 @@ dependencies:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "velero: update from 3.1.2 to 4.0.2"
+      description: "cert-manager: update from 1.11.1 to 1.12.0"
       links:
         - name: GitHub Release
-          url: https://github.com/vmware-tanzu/helm-charts/releases/tag/velero-4.0.2
+          url: https://github.com/cert-manager/cert-manager/releases/tag/v1.12.0
+    - kind: changed
+      description: "cert-manager: update chart from 1.11.1 to 1.12.0"
+      links:
+        - name: "feat: Add imagePullSecrets for AMCE http01 solver pod"
+          url: https://github.com/cert-manager/cert-manager/pull/5801
+        - name: "feat: Vault issuer can now use a serviceAccountRef instead of relying on static service account tokens"
+          url: https://github.com/cert-manager/cert-manager/pull/5502

--- a/charts/infra-apps/README.md
+++ b/charts/infra-apps/README.md
@@ -1,6 +1,6 @@
 # infra-apps
 
-![Version: 0.160.0](https://img.shields.io/badge/Version-0.160.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.161.0](https://img.shields.io/badge/Version-0.161.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Argo CD app-of-apps config for infrastructure components
 
@@ -38,7 +38,7 @@ This chart is maintained by [Adfinis](https://adfinis.com/?pk_campaign=github&pk
 | certManager.destination.namespace | string | `"infra-certmanager"` | Namespace |
 | certManager.enabled | bool | `false` | Enable cert-manager |
 | certManager.repoURL | string | [repo](https://charts.jetstack.io) | Repo URL |
-| certManager.targetRevision | string | `"1.11.1"` | [cert-manager Helm chart](https://github.com/jetstack/cert-manager/tree/master/deploy/charts/cert-manager) version |
+| certManager.targetRevision | string | `"1.12.0"` | [cert-manager Helm chart](https://github.com/jetstack/cert-manager/tree/master/deploy/charts/cert-manager) version |
 | certManager.values | object | [upstream values](https://github.com/jetstack/cert-manager/blob/master/deploy/charts/cert-manager/values.yaml) | Helm values |
 | certManagerIssuers | object | [example](./examples/cert-manager-issuers.yaml) | [cert-manager-issuers](https://cert-manager.io/docs/configuration/) |
 | certManagerIssuers.annotations | object | `{}` | Annotations for cert-manager-issuers app |

--- a/charts/infra-apps/values.yaml
+++ b/charts/infra-apps/values.yaml
@@ -42,7 +42,7 @@ certManager:
   # -- Chart
   chart: cert-manager
   # -- [cert-manager Helm chart](https://github.com/jetstack/cert-manager/tree/master/deploy/charts/cert-manager) version
-  targetRevision: 1.11.1
+  targetRevision: 1.12.0
   # -- Helm values
   # @default -- [upstream values](https://github.com/jetstack/cert-manager/blob/master/deploy/charts/cert-manager/values.yaml)
   values: {}


### PR DESCRIPTION
# Description

Update cert-manager from 1.11.1 to 1.12.0: https://github.com/cert-manager/cert-manager/releases/tag/v1.12.0

New features:
- Add imagePullSecrets for AMCE http01 solver pod: https://github.com/cert-manager/cert-manager/pull/5801
- Vault issuer can now use a serviceAccountRef instead of relying on static service account tokens: https://github.com/cert-manager/cert-manager/pull/5502

# Checklist

<!--
    Take care of the default items before marking your PR as ready for review,
    be prepared to add more items.
-->

* [x] This PR contains a description of the changes I'm making
* [x] I updated the version in Chart.yaml
* [x] I updated the changelog with an `artifacthub.io/changes` annotation in `Chart.yaml`, check the [example](docs/development.md#Changelog) in the documentation.
* [x] I updated applicable README.md files using  `pre-commit run`
* [x] I documented any high-level concepts I'm introducing in `docs/`
* [x] CI is currently green and this is ready for review
* [x] I am ready to test changes after they are applied and released

<!--
    Please open PRs as Draft while you make CI green and/or finalise
    documentation. Your PR will be assigned to a CODEOWNER once you mark it
    as "Ready for Review".

   Once it is approved we will squash your changes onto the default branch
   and our trusty bot account will release them to the repository.
-->
