### PR TITLE
fix(infra-apps): upgrade ingress-nginx chart to 4.8.3

### DIFF
--- a/charts/infra-apps/Chart.yaml
+++ b/charts/infra-apps/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: infra-apps
 description: Argo CD app-of-apps config for infrastructure components
 type: application
-version: 0.182.0
+version: 0.183.0
 home: https://github.com/adfinis/helm-charts/tree/main/charts/infra-apps
 sources:
   - https://github.com/adfinis/helm-charts
@@ -15,27 +15,10 @@ dependencies:
     version: 0.9.0
     repository: https://charts.adfinis.com
 annotations:
+  artifacthub.io/containsSecurityUpdates: "true"
   artifacthub.io/changes: |
-    - kind: changed
-      description: "feat(infra-apps): Update kured from 4.2.0 to 5.2.0"
+    - kind: security
+      description: "feat(infra-apps): Update ingress-nginx from 4.7.1 to 4.8.3"
       links:
-        - name: "fix: annotate nodes for reboot before aborting due to blocked"
-          url: https://github.com/kubereboot/kured/pull/749
-        - name: "update docs location"
-          url: https://github.com/kubereboot/kured/pull/758
-        - name: "feat: metrics port command"
-          url: https://github.com/kubereboot/kured/pull/780
-        - name: "Support pod-selector for drain command"
-          url: https://github.com/kubereboot/kured/pull/788
-        - name: "Use readOnlyRootFilesystem"
-          url: https://github.com/kubereboot/kured/pull/805
-        - name: "Log on unusual sentinel-command exit code"
-          url: https://github.com/kubereboot/kured/pull/806
-        - name: "Don’t hold node lock if reboot is blocked"
-          url: https://github.com/kubereboot/kured/pull/819
-        - name: "Add argument to invert the behavior of alert-filter-regexp"
-          url: https://github.com/kubereboot/kured/pull/786
-        - name: "Add multiple concurrent node reboot"
-          url: https://github.com/kubereboot/kured/pull/660
-        - name: "Adds new flag --metrics-host"
-          url: https://github.com/kubereboot/kured/pull/811
+        - name: "fix: updates to ingress-nginx 1.9.4 to fix CVE-2023-5043 and CVE-2023-5044"
+          url: https://github.com/kubernetes/ingress-nginx/pull/10568

--- a/charts/infra-apps/README.md
+++ b/charts/infra-apps/README.md
@@ -1,6 +1,6 @@
 # infra-apps
 
-![Version: 0.182.0](https://img.shields.io/badge/Version-0.182.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.183.0](https://img.shields.io/badge/Version-0.183.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Argo CD app-of-apps config for infrastructure components
 
@@ -62,7 +62,7 @@ This chart is maintained by [Adfinis](https://adfinis.com/?pk_campaign=github&pk
 | ingressNginx.destination.namespace | string | `"infra-ingress"` | Namespace |
 | ingressNginx.enabled | bool | `false` | Configure nginx-ingress |
 | ingressNginx.repoURL | string | [repo](https://kubernetes.github.io/ingress-nginx) | Repo URL |
-| ingressNginx.targetRevision | string | `"4.7.1"` | [ingress-nginx Helm chart](https://github.com/kubernetes/ingress-nginx/tree/main/charts/ingress-nginx) version |
+| ingressNginx.targetRevision | string | `"4.8.3"` | [ingress-nginx Helm chart](https://github.com/kubernetes/ingress-nginx/tree/main/charts/ingress-nginx) version |
 | ingressNginx.values | object | [upstream values](https://github.com/kubernetes/ingress-nginx/blob/main/charts/ingress-nginx/values.yaml) | Helm values |
 | kubeEventExporter | object | [example](./examples/kubernetes-event-exporter.yaml) | [kubernetes-event-exporter](https://github.com/resmoio/kubernetes-event-exporter) |
 | kubeEventExporter.annotations | object | `{}` | Annotations for kubernetes-event-exporter app |

--- a/charts/infra-apps/values.yaml
+++ b/charts/infra-apps/values.yaml
@@ -111,7 +111,7 @@ ingressNginx:
   # -- Chart
   chart: ingress-nginx
   # -- [ingress-nginx Helm chart](https://github.com/kubernetes/ingress-nginx/tree/main/charts/ingress-nginx) version
-  targetRevision: 4.7.1
+  targetRevision: 4.8.3
   # -- Helm values
   # @default -- [upstream values](https://github.com/kubernetes/ingress-nginx/blob/main/charts/ingress-nginx/values.yaml)
   values: {}


### PR DESCRIPTION
# Description

Upgrade ingress-nginx chart to 4.8.3 to update the `ingress-nginx` image to 1.9.4 to fix CVEs CVE-2023-5043 & CVE-2023-5044.

# Checklist

* [x] This PR contains a description of the changes I'm making
* [x] I updated the version in Chart.yaml
* [x] I updated the changelog with an `artifacthub.io/changes` annotation in `Chart.yaml`, check the [example](docs/development.md#Changelog) in the documentation.
* [x] I updated applicable README.md files using  `pre-commit run`
* [x] I documented any high-level concepts I'm introducing in `docs/`
* [x] CI is currently green and this is ready for review
* [x] I am ready to test changes after they are applied and released