### PR TITLE
feat(infra-logging): add extraObjects field

### DIFF
--- a/charts/logging-apps/Chart.yaml
+++ b/charts/logging-apps/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: logging-apps
 description: Argo CD app-of-apps config for logging applications
 type: application
-version: 0.27.0
+version: 0.27.1
 home: https://github.com/adfinis/helm-charts/tree/main/charts/logging-apps
 sources:
   - https://github.com/adfinis/helm-charts
@@ -16,90 +16,5 @@ dependencies:
     repository: https://charts.adfinis.com
 annotations:
   artifacthub.io/changes: |
-    - kind: changed
-      description: 'chore(fluentBit): update chart from 0.21.6 to 0.39.0'
-      links:
-        - name: GitHub release of helm-chart 0.39.0
-          url: https://github.com/fluent/helm-charts/releases/tag/fluent-bit-0.39.0
-        - name: GitHub release of Fluent Bit v2.1.10
-          url: https://github.com/fluent/fluent-bit/releases/tag/v2.1.10
-        - name: GitHub release of helm-chart 0.38.0
-          url: https://github.com/fluent/helm-charts/releases/tag/fluent-bit-0.38.0
-        - name: GitHub release of Fluent Bit v2.1.9
-          url: https://github.com/fluent/fluent-bit/releases/tag/v2.1.9
-        - name: GitHub release of helm-chart 0.37.1
-          url: https://github.com/fluent/helm-charts/releases/tag/fluent-bit-0.37.1
-        - name: GitHub release of Fluent Bit v2.1.8
-          url: https://github.com/fluent/fluent-bit/releases/tag/v2.1.8
-        - name: GitHub release of helm-chart 0.37.0
-          url: https://github.com/fluent/helm-charts/releases/tag/fluent-bit-0.37.0
-        - name: GitHub release of helm-chart 0.36.0
-          url: https://github.com/fluent/helm-charts/releases/tag/fluent-bit-0.36.0
-        - name: GitHub release of Fluent Bit v2.1.7
-          url: https://github.com/fluent/fluent-bit/releases/tag/v2.1.7
-        - name: GitHub release of helm-chart 0.35.1
-          url: https://github.com/fluent/helm-charts/releases/tag/fluent-bit-0.35.1
-        - name: GitHub release of helm-chart 0.35.0
-          url: https://github.com/fluent/helm-charts/releases/tag/fluent-bit-0.35.0
-        - name: GitHub release of helm-chart 0.34.2
-          url: https://github.com/fluent/helm-charts/releases/tag/fluent-bit-0.34.2
-        - name: GitHub release of Fluent Bit v2.1.6
-          url: https://github.com/fluent/fluent-bit/releases/tag/v2.1.6
-        - name: GitHub release of helm-chart 0.34.1
-          url: https://github.com/fluent/helm-charts/releases/tag/fluent-bit-0.34.1
-        - name: GitHub release of helm-chart 0.34.0
-          url: https://github.com/fluent/helm-charts/releases/tag/fluent-bit-0.34.0
-        - name: GitHub release of helm-chart 0.33.0
-          url: https://github.com/fluent/helm-charts/releases/tag/fluent-bit-0.33.0
-        - name: GitHub release of helm-chart 0.32.2
-          url: https://github.com/fluent/helm-charts/releases/tag/fluent-bit-0.32.2
-        - name: GitHub release of Fluent Bit v2.1.5
-          url: https://github.com/fluent/fluent-bit/releases/tag/v2.1.5
-        - name: GitHub release of helm-chart 0.32.1
-          url: https://github.com/fluent/helm-charts/releases/tag/fluent-bit-0.32.1
-        - name: GitHub release of helm-chart 0.32.0
-          url: https://github.com/fluent/helm-charts/releases/tag/fluent-bit-0.32.0
-        - name: GitHub release of helm-chart 0.31.0
-          url: https://github.com/fluent/helm-charts/releases/tag/fluent-bit-0.31.0
-        - name: GitHub release of helm-chart 0.30.4
-          url: https://github.com/fluent/helm-charts/releases/tag/fluent-bit-0.30.4
-        - name: GitHub release of Fluent Bit v2.1.4
-          url: https://github.com/fluent/fluent-bit/releases/tag/v2.1.4
-        - name: GitHub release of helm-chart 0.30.3
-          url: https://github.com/fluent/helm-charts/releases/tag/fluent-bit-0.30.3
-        - name: GitHub release of helm-chart 0.30.2
-          url: https://github.com/fluent/helm-charts/releases/tag/fluent-bit-0.30.2
-        - name: GitHub release of helm-chart 0.30.1
-          url: https://github.com/fluent/helm-charts/releases/tag/fluent-bit-0.30.1
-        - name: GitHub release of helm-chart 0.30.0
-          url: https://github.com/fluent/helm-charts/releases/tag/fluent-bit-0.30.0
-        - name: GitHub release of helm-chart 0.29.0
-          url: https://github.com/fluent/helm-charts/releases/tag/fluent-bit-0.29.0
-        - name: GitHub release of Fluent Bit v2.1.3
-          url: https://github.com/fluent/fluent-bit/releases/tag/v2.1.3
-        - name: GitHub release of helm-chart 0.28.0
-          url: https://github.com/fluent/helm-charts/releases/tag/fluent-bit-0.28.0
-        - name: GitHub release of Fluent Bit v2.1.2
-          url: https://github.com/fluent/fluent-bit/releases/tag/v2.1.2
-        - name: GitHub release of helm-chart 0.27.0
-          url: https://github.com/fluent/helm-charts/releases/tag/fluent-bit-0.27.0
-        - name: GitHub release of Fluent Bit v2.0.11
-          url: https://github.com/fluent/fluent-bit/releases/tag/v2.0.11
-        - name: GitHub release of helm-chart 0.26.0
-          url: https://github.com/fluent/helm-charts/releases/tag/fluent-bit-0.26.0
-        - name: GitHub release of helm-chart 0.25.0
-          url: https://github.com/fluent/helm-charts/releases/tag/fluent-bit-0.25.0
-        - name: GitHub release of Fluent Bit v2.0.10
-          url: https://github.com/fluent/fluent-bit/releases/tag/v2.0.10
-        - name: GitHub release of helm-chart 0.24.0
-          url: https://github.com/fluent/helm-charts/releases/tag/fluent-bit-0.24.0
-        - name: GitHub release of Fluent Bit v2.0.9
-          url: https://github.com/fluent/fluent-bit/releases/tag/v2.0.9
-        - name: GitHub release of helm-chart 0.23.0
-          url: https://github.com/fluent/helm-charts/releases/tag/fluent-bit-0.23.0
-        - name: GitHub release of Fluent Bit v2.0.8
-          url: https://github.com/fluent/fluent-bit/releases/tag/v2.0.8
-        - name: GitHub release of helm-chart 0.22.0
-          url: https://github.com/fluent/helm-charts/releases/tag/fluent-bit-0.22.0
-        - name: GitHub release of helm-chart 0.21.7
-          url: https://github.com/fluent/helm-charts/releases/tag/fluent-bit-0.21.7
+    - kind: added
+      description: feat(): add extraObjects field

--- a/charts/logging-apps/README.md
+++ b/charts/logging-apps/README.md
@@ -1,6 +1,6 @@
 # logging-apps
 
-![Version: 0.27.0](https://img.shields.io/badge/Version-0.27.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.27.1](https://img.shields.io/badge/Version-0.27.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Argo CD app-of-apps config for logging applications
 
@@ -51,6 +51,7 @@ This chart is maintained by [Adfinis](https://adfinis.com/?pk_campaign=github&pk
 | lokiStack.repoURL | string | [repo](https://grafana.github.io/helm-charts) | Repo URL |
 | lokiStack.targetRevision | string | `"2.9.10"` | [loki-stack Helm chart](https://github.com/grafana/helm-charts/tree/main/charts/loki-stack) version |
 | lokiStack.values | object | [upstream values](https://github.com/grafana/helm-charts/blob/main/charts/loki-stack/values.yaml) | Helm values |
+| extraObjects | object | `[]` | list of additional manifests to deploy |
 
 ## About this chart
 

--- a/charts/logging-apps/templates/extra-manifests.yaml
+++ b/charts/logging-apps/templates/extra-manifests.yaml
@@ -1,0 +1,4 @@
+{{ range .Values.extraObjects }}
+---
+{{ tpl (toYaml .) $ }}
+{{ end }}

--- a/charts/logging-apps/values.yaml
+++ b/charts/logging-apps/values.yaml
@@ -77,3 +77,5 @@ fluentBit:
   # -- Helm values
   # @default -- [upstream values](https://github.com/fluent/helm-charts/blob/main/charts/fluent-bit/values.yaml)
   values: {}
+
+extraObjects: []


### PR DESCRIPTION
# Description

Latest version of  `loki` helm chart comes with `extraObjects` variable which can be used to deploy additional resources. However, `loki-stack` chart must stayed behind, because mentioned variable is not present. Because of that I added `extraObjects` field to `infra-logging` chart.

# Issues

Unable to deploy additional resources alongside `loki-stack`.

# Checklist

* [x] This PR contains a description of the changes I'm making
* [x] I updated the version in Chart.yaml
* [x] I updated the changelog with an `artifacthub.io/changes` annotation in `Chart.yaml`, check the [example](docs/development.md#Changelog) in the documentation.
* [x] I updated applicable README.md files using  `pre-commit run`
* [x] I documented any high-level concepts I'm introducing in `docs/`
* [ ] CI is currently green and this is ready for review
* [ ] I am ready to test changes after they are applied and released