### PR TITLE
chore(openshift-etcd-backup): update openshift-etcd-backup image to v1.6.17

### DIFF
--- a/charts/openshift-etcd-backup/Chart.yaml
+++ b/charts/openshift-etcd-backup/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: openshift-etcd-backup
 description: Chart for openshift-etcd-backup solution
 type: application
-version: 1.6.16
-appVersion: v1.6.16
+version: 1.6.17
+appVersion: v1.6.17
 keywords:
   - openshift-etcd-backup
   - openshift
@@ -20,7 +20,7 @@ maintainers:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "bump openshift-etcd-backup image to v1.6.16"
+      description: "bump openshift-etcd-backup image to v1.6.17"
       links:
-        - name: openshift-etcd-backup release v1.6.15
-          url: https://github.com/adfinis/openshift-etcd-backup/releases/tag/v1.6.16
+        - name: openshift-etcd-backup release v1.6.17
+          url: https://github.com/adfinis/openshift-etcd-backup/releases/tag/v1.6.17

--- a/charts/openshift-etcd-backup/README.md
+++ b/charts/openshift-etcd-backup/README.md
@@ -1,6 +1,6 @@
 # openshift-etcd-backup
 
-![Version: 1.6.16](https://img.shields.io/badge/Version-1.6.16-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.6.16](https://img.shields.io/badge/AppVersion-v1.6.16-informational?style=flat-square)
+![Version: 1.6.17](https://img.shields.io/badge/Version-1.6.17-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.6.17](https://img.shields.io/badge/AppVersion-v1.6.17-informational?style=flat-square)
 
 Chart for openshift-etcd-backup solution
 


### PR DESCRIPTION
# Description

Bump openshift-etcd-backup image to v1.6.17, which uses the newly released RHEL 8.9 base image.

# Checklist

* [x] This PR contains a description of the changes I'm making
* [x] I updated the version in Chart.yaml
* [x] I updated the changelog with an `artifacthub.io/changes` annotation in `Chart.yaml`, check the [example](docs/development.md#Changelog) in the documentation.
* [x] I updated applicable README.md files using  `pre-commit run`
* [x] I documented any high-level concepts I'm introducing in `docs/`
* [x] CI is currently green and this is ready for review
* [x] I am ready to test changes after they are applied and released