### PR TITLE
Fix VaultAutopilotHealthy alert name and time window in alert descriptions

### DIFF
--- a/charts/vault-monitoring/Chart.yaml
+++ b/charts/vault-monitoring/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vault-monitoring
 description: monitor your vault server from within Kubernetes' prometheus
 type: application
-version: 0.3.1
+version: 0.4.0
 home: https://github.com/adfinis/helm-charts/tree/main/charts/vault-monitoring
 sources:
   - https://github.com/adfinis/helm-charts/tree/main/charts/vault-monitoring

--- a/charts/vault-monitoring/README.md
+++ b/charts/vault-monitoring/README.md
@@ -1,6 +1,6 @@
 # vault-monitoring
 
-![Version: 0.3.1](https://img.shields.io/badge/Version-0.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.4.0](https://img.shields.io/badge/Version-0.4.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 monitor your vault server from within Kubernetes' prometheus
 

--- a/charts/vault-monitoring/values.yaml
+++ b/charts/vault-monitoring/values.yaml
@@ -54,9 +54,7 @@ prometheusRules:
   # -- set of prometheus alerts to define
   # @default -- list of predefined alerts
   rules:
-    - alert: VaultAutopilotNodeHealthy
-      # Set to 1 if Autopilot considers all nodes healthy
-      # https://www.vaultproject.io/docs/internals/telemetry#integrated-storage-raft-autopilot
+    - alert: VaultAutopilotHealthy
       expr: vault_autopilot_healthy < 1
       for: 1m
       labels:

--- a/charts/vault-monitoring/values.yaml
+++ b/charts/vault-monitoring/values.yaml
@@ -93,7 +93,7 @@ prometheusRules:
         severity: critical
       annotations:
         summary: High frequency of failed Vault requests
-        description: There has been an increased number of failed Vault requests in the last 15 minutes
+        description: There has been an increased number of failed Vault requests in the last 20 minutes
     - alert: VaultResponseFailures
       expr: increase(vault_audit_log_response_failure[5m]) > 0
       for: 15m
@@ -101,7 +101,7 @@ prometheusRules:
         severity: critical
       annotations:
         summary: High frequency of failed Vault responses
-        description: There has been an increased number of failed Vault responses in the last 15 minutes
+        description: There has been an increased number of failed Vault responses in the last 20 minutes
     - alert: VaultTokenCreate
       expr: increase(vault_token_create_count[5m]) > 100
       for: 15m
@@ -109,7 +109,7 @@ prometheusRules:
         severity: critical
       annotations:
         summary: High frequency of created Vault token
-        description: There has been an increased number of Vault token creation in the last 15 minutes
+        description: There has been an increased number of Vault token creation in the last 20 minutes
     - alert: VaultTokenStore
       expr: increase(vault_token_store_count[5m]) > 100
       for: 15m
@@ -117,4 +117,4 @@ prometheusRules:
         severity: critical
       annotations:
         summary: High frequency of stored Vault token
-        description: There has been an increased number of Vault token storing in the last 15 minutes
+        description: There has been an increased number of Vault token storing in the last 20 minutes


### PR DESCRIPTION
I would like to improve the alert name for the autopilot.

* https://developer.hashicorp.com/vault/docs/internals/telemetry/metrics/all#vault-autopilot-healthy
* https://developer.hashicorp.com/vault/docs/internals/telemetry/metrics/all#vault-autopilot-node-healthy

Also, I noticed a link that no longer points to a meaningful location. We can remove it.
