### PR TITLE
ci(release): add skip_existing to chart-releaser action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,6 +31,9 @@ jobs:
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.6.0
+        with:
+          # Allow us to re-run the release action
+          skip_existing: true
         env:
           CR_TOKEN: "${{ secrets.CR_TOKEN }}"
 


### PR DESCRIPTION
# Description

Add `skip_existing` to chart-releaser action to allow us to re-run the release action.

# Checklist

* [x] This PR contains a description of the changes I'm making
* [x] CI is currently green and this is ready for review
* [x] I am ready to test changes after they are applied and released