### PR TITLE
chore(azure-apps): Bump azureKvCsiProvider to v1.5.4

### DIFF
--- a/charts/azure-apps/Chart.yaml
+++ b/charts/azure-apps/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: azure-apps
 description: Argo CD app-of-apps config for Azure applications
 type: application
-version: 0.13.2
+version: 0.13.3
 home: https://github.com/adfinis/helm-charts/tree/main/charts/azure-apps
 sources:
   - https://github.com/adfinis/helm-charts
@@ -17,4 +17,15 @@ dependencies:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "fix: README for `azureWorkloadIdentityWebhook`"
+      description: "azureKvCsiProvider bump azureKvCsiProvider from v1.4.1 to v1.5.4"
+      links:
+        - name: "Handles the case where the optional leaf SKI is missing"
+          url: https://github.com/Azure/secrets-store-csi-driver-provider-azure/releases/tag/v1.5.2
+        - name: "bump golang.org/x/net from 0.17.0 to 0.24.0"
+          url: https://github.com/Azure/secrets-store-csi-driver-provider-azure/releases/tag/v1.5.2
+        - name: "CVE 2024 24786: bump google.golang.org protobuf to v1.33.0"
+          url: https://github.com/Azure/secrets-store-csi-driver-provider-azure/releases/tag/v1.5.2
+        - name: "bump crypto from 0.14.0 to 0.18.0"
+          url: https://github.com/Azure/secrets-store-csi-driver-provider-azure/releases/tag/v1.5.1
+        - name: "bump from v1.4.1 to v1.5.0"
+          url: https://github.com/Azure/secrets-store-csi-driver-provider-azure/releases/tag/v1.5.0

--- a/charts/azure-apps/README.md
+++ b/charts/azure-apps/README.md
@@ -1,6 +1,6 @@
 # azure-apps
 
-![Version: 0.13.2](https://img.shields.io/badge/Version-0.13.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.13.3](https://img.shields.io/badge/Version-0.13.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Argo CD app-of-apps config for Azure applications
 
@@ -28,7 +28,7 @@ This chart is maintained by [Adfinis](https://adfinis.com/?pk_campaign=github&pk
 | azureKvCsiProvider.destination.namespace | string | `"kube-system"` | Namespace |
 | azureKvCsiProvider.enabled | bool | `false` | Enable secrets-store-csi-driver-provider-azure |
 | azureKvCsiProvider.repoURL | string | [repo](https://azure.github.io/secrets-store-csi-driver-provider-azure/charts) | Repo URL |
-| azureKvCsiProvider.targetRevision | string | `"1.4.1"` | [csi-secrets-store-provider-azure Helm chart](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/charts/csi-secrets-store-provider-azure) version |
+| azureKvCsiProvider.targetRevision | string | `"1.5.4"` | [csi-secrets-store-provider-azure Helm chart](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/charts/csi-secrets-store-provider-azure) version |
 | azureKvCsiProvider.values | object | [upstream values](https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/charts/csi-secrets-store-provider-azure/values.yaml) | Helm values |
 | azureWorkloadIdentityWebhook | object | - | [azure-workload-identity](https://azure.github.io/azure-workload-identity) ([example](./examples/azure-workload-identity-webhook.yaml)) |
 | azureWorkloadIdentityWebhook.chart | string | `"azure-workload-identity-webhook"` | Chart |

--- a/charts/azure-apps/values.yaml
+++ b/charts/azure-apps/values.yaml
@@ -13,7 +13,7 @@ azureKvCsiProvider:
   # -- Chart
   chart: "csi-secrets-store-provider-azure"
   # -- [csi-secrets-store-provider-azure Helm chart](https://github.com/Azure/secrets-store-csi-driver-provider-azure/tree/master/charts/csi-secrets-store-provider-azure) version
-  targetRevision: "1.4.1"
+  targetRevision: "1.5.4"
   # -- Helm values
   # @default -- [upstream values](https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/charts/csi-secrets-store-provider-azure/values.yaml)
   values: {}


### PR DESCRIPTION
<!--
    Thank you for your contribution. Please use this template to help guide
    you towards preparing a PR that fullfills our merge requirements.
-->
# Description

Update azureKvCsiProvider from 1.4.1 to 1.5.4

  - [fix: Handles the case where the optional leaf SKI is missing](https://github.com/Azure/secrets-store-csi-driver-provider-azure/releases/tag/v1.5.2)
  - [chore: bump golang.org/x/net from 0.17.0 to 0.24.0](https://github.com/Azure/secrets-store-csi-driver-provider-azure/releases/tag/v1.5.2)
  - [security: CVE-2024-24786: bump google.golang.org/protobuf to v1.33.0](https://github.com/Azure/secrets-store-csi-driver-provider-azure/releases/tag/v1.5.2)
  - [chore: bump golang.org/x/crypto from 0.14.0 to 0.18.0](https://github.com/Azure/secrets-store-csi-driver-provider-azure/releases/tag/v1.5.1)
  - [bump from v1.4.1 to v1.5.0](https://github.com/Azure/secrets-store-csi-driver-provider-azure/releases/tag/v1.5.0)
 
# Issues

* fixes #1237

# Checklist

* [x] This PR contains a description of the changes I'm making
* [x] I updated the version in Chart.yaml
* [x] I updated the changelog with an `artifacthub.io/changes` annotation in `Chart.yaml`, check the [example](docs/development.md#Changelog) in the documentation.
* [x] I updated applicable README.md files using  `pre-commit run`
* [x] I documented any high-level concepts I'm introducing in `docs/`
* [x] CI is currently green and this is ready for review
* [x] I am ready to test changes after they are applied and released

