### PR TITLE
feat(security-apps): Bump vault-monitoring to 0.4.0

### DIFF
--- a/charts/security-apps/Chart.yaml
+++ b/charts/security-apps/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: security-apps
 description: Argo CD app-of-apps config for security applications
 type: application
-version: 0.85.0
+version: 0.86.0
 home: https://github.com/adfinis/helm-charts/tree/main/charts/security-apps
 sources:
   - https://github.com/adfinis/helm-charts

--- a/charts/security-apps/README.md
+++ b/charts/security-apps/README.md
@@ -137,7 +137,7 @@ This chart is maintained by [Adfinis](https://adfinis.com/?pk_campaign=github&pk
 | vaultMonitoring.destination.namespace | string | `"infra-vault"` | Namespace |
 | vaultMonitoring.enabled | bool | `false` | Enable vault-monitoring |
 | vaultMonitoring.repoURL | string | [repo](https://charts.adfinis.com) | Repo URL |
-| vaultMonitoring.targetRevision | string | `"0.2.*"` | [vault-monitoring Helm chart](https://github.com/adfinis/helm-charts/tree/main/charts/vault-monitoring) version |
+| vaultMonitoring.targetRevision | string | `"0.4.0"` | [vault-monitoring Helm chart](https://github.com/adfinis/helm-charts/tree/main/charts/vault-monitoring) version |
 | vaultMonitoring.values | object | [upstream values](https://github.com/adfinis/helm-charts/blob/main/charts/vault-monitoring/values.yaml) | Helm values |
 
 ## About this chart

--- a/charts/security-apps/README.md
+++ b/charts/security-apps/README.md
@@ -1,6 +1,6 @@
 # security-apps
 
-![Version: 0.85.0](https://img.shields.io/badge/Version-0.85.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.86.0](https://img.shields.io/badge/Version-0.86.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Argo CD app-of-apps config for security applications
 

--- a/charts/security-apps/values.yaml
+++ b/charts/security-apps/values.yaml
@@ -161,7 +161,7 @@ vaultMonitoring:
   # -- Chart
   chart: "vault-monitoring"
   # -- [vault-monitoring Helm chart](https://github.com/adfinis/helm-charts/tree/main/charts/vault-monitoring) version
-  targetRevision: "0.2.*"
+  targetRevision: "0.4.0"
   # -- Helm values
   # @default -- [upstream values](https://github.com/adfinis/helm-charts/blob/main/charts/vault-monitoring/values.yaml)
   values: {}


### PR DESCRIPTION
This is a follow up of https://github.com/adfinis/helm-charts/pull/1159

vault-monitoring-0.3.0 got released and tagged in the meantime.

We can go ahead here once we finished https://github.com/adfinis/helm-charts/pull/1157