### PR TITLE
[issue 1270] Feature: disable operator templates generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Chart for HedgeDoc, a fork of CodiMD
 [<img alt="hedgedoc" src="https://raw.githubusercontent.com/hedgedoc/hedgedoc-logo/main/LOGOTYPE/PNG/HedgeDoc-Logo%201.png" width="128">](charts/hedgedoc)
 #### [keycloak-operator](charts/keycloak-operator) chart
 
-![Version: 1.1.x](https://img.shields.io/badge/version-1.1.x-brightgreen) ![App version: 24..x](https://img.shields.io/badge/app%20version-24..x-brightgreen)
+![Version: 1.2.x](https://img.shields.io/badge/version-1.2.x-brightgreen) ![App version: 24..x](https://img.shields.io/badge/app%20version-24..x-brightgreen)
 
 Deploy Keycloak Operator and Keycloak
 

--- a/charts/keycloak-operator/Chart.yaml
+++ b/charts/keycloak-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: keycloak-operator
 description: Deploy Keycloak Operator and Keycloak
 type: application
-version: 1.1.0
+version: 1.2.0
 appVersion: "24.0.4"
 icon: https://www.keycloak.org/resources/images/logo-stacked.svg
 home: https://www.keycloak.org
@@ -16,23 +16,7 @@ maintainers:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "Bump Keycloak 23.0.3 to 24.0.4"
+      description: "New feature: disable Operator templates generation"
       links:
-        - name: "Release 24.0.4"
-          url: https://www.keycloak.org/2024/05/keycloak-2404-released.html
-        - name: "Release 24.0.3"
-          url: https://www.keycloak.org/2024/04/keycloak-2403-released.html
-        - name: "Release 24.0.2"
-          url: https://www.keycloak.org/2024/03/keycloak-2402-released.html
-        - name: "Release 24.0.1"
-          url: https://www.keycloak.org/2024/03/keycloak-2401-released.html
-        - name: "Release 24.0.0"
-          url: https://www.keycloak.org/2024/03/keycloak-2400-released.html
-        - name: "Release 23.0.7"
-          url: https://www.keycloak.org/2024/02/keycloak-2307-released.html
-        - name: "Release 23.0.6"
-          url: https://www.keycloak.org/2024/02/keycloak-2306-released.html
-        - name: "Release 23.0.5"
-          url: https://www.keycloak.org/2024/01/keycloak-2305-released.html
-        - name: "Release 23.0.4"
-          url: https://www.keycloak.org/2024/01/keycloak-2304-released.html
+        - name: "Issue 1270"
+          url: https://github.com/adfinis/helm-charts/issues/1270

--- a/charts/keycloak-operator/README.md
+++ b/charts/keycloak-operator/README.md
@@ -1,6 +1,6 @@
 # keycloak-operator
 
-![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 24.0.4](https://img.shields.io/badge/AppVersion-24.0.4-informational?style=flat-square)
+![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 24.0.4](https://img.shields.io/badge/AppVersion-24.0.4-informational?style=flat-square)
 
 Deploy Keycloak Operator and Keycloak
 
@@ -16,68 +16,67 @@ This chart is maintained by [Adfinis](https://adfinis.com/?pk_campaign=github&pk
 
 ## Values
 
-| Key                                      | Type | Default | Description |
-|------------------------------------------|------|---------|-------------|
-| fullnameOverride                         | string | `""` |  |
-| imagePullSecrets                         | list | `[]` |  |
-| keycloak.additionalOptions               | string | `nil` | Configuration of the Keycloak server expressed as a keys and values that can be either direct values or references to secrets. |
-| keycloak.db.database                     | string | `nil` | Sets the database name of the default JDBC URL of the chosen vendor. If the `url` option is set, this option is ignored. |
-| keycloak.db.host                         | string | `nil` | Sets the hostname of the default JDBC URL of the chosen vendor. If the `url` option is set, this option is ignored. |
-| keycloak.db.passwordSecret               | string | `nil` | The reference to a secret holding the password of the database user. |
-| keycloak.db.poolInitialSize              | string | `nil` | The initial size of the connection pool. |
-| keycloak.db.poolMaxSize                  | string | `nil` | The maximum size of the connection pool. |
-| keycloak.db.poolMinSize                  | string | `nil` | The minimal size of the connection pool. |
-| keycloak.db.port                         | string | `nil` | Sets the port of the default JDBC URL of the chosen vendor. If the `url` option is set, this option is ignored. |
-| keycloak.db.schema                       | string | `nil` | The database schema to be used. |
-| keycloak.db.url                          | string | `nil` | The full database JDBC URL. If not provided, a default URL is set based on the selected database vendor. |
-| keycloak.db.usernameSecret               | string | `nil` | The reference to a secret holding the username of the database user. |
-| keycloak.db.vendor                       | string | `nil` | The database vendor. |
-| keycloak.enabled                         | bool | `false` | Enable deploying a bundled keycloak with the operator |
-| keycloak.features                        | object | see [Keycloak docs](https://www.keycloak.org/server/features) | Configure Keycloak features |
-| keycloak.features.disabled               | list | `[]` | Disabled Keycloak features |
-| keycloak.features.enabled                | list | `[]` | Enabled Keycloak features |
-| keycloak.hostname.admin                  | string | `nil` | The hostname for accessing the administration console. |
-| keycloak.hostname.adminUrl               | string | `nil` | Set the base URL for accessing the administration console. |
-| keycloak.hostname.hostname               | string | Disabled if not set. | Hostname for the Keycloak server. |
-| keycloak.hostname.strict                 | bool | `false` | Disables dynamically resolving the hostname from request headers |
-| keycloak.hostname.strictBackchannel      | bool | `true` | By default backchannel URLs are dynamically resolved from request headers to allow internal and external applications. |
-| keycloak.http.httpEnabled                | bool | `true` | Enable a HTTP listener |
-| keycloak.http.httpPort                   | string | `nil` | The used HTTP port |
-| keycloak.http.httpsPort                  | string | `nil` | The used HTTPS port |
-| keycloak.http.tlsSecret                  | string | `nil` | A secret containing the TLS configuration for HTTPS. |
-| keycloak.image.repository                | string | `""` | Overrides the operator.keycloakImage.image value whose default is quay.io/keycloak/keycloak |
-| keycloak.image.tag                       | string | `""` | Overrides the operator.keycloakImage.tag value whose default is the chart appVersion. |
-| keycloak.imagePullSecrets                | string | `nil` | Secret(s) that might be used when pulling an image from a private container image registry or repository. |
-| keycloak.ingress.annotations             | list | `[]` | Annotations for the Ingress |
-| keycloak.ingress.className               | string | `""` | Ingress class name |
-| keycloak.ingress.enabled                 | bool | `true` | The deployment is, by default, exposed through a basic ingress. |
-| keycloak.instances                       | int | `1` | Number of Keycloak instances in HA mode. |
-| keycloak.realmimport.enabled             | bool | `false` | Deploy realmimport resources |
-| keycloak.realmimport.realms              | list | `[]` | A list of realms to configure using the realmimport CRD. |
-| keycloak.transaction.xaEnabled           | bool | `false` | Determine whether Keycloak should use a non-XA datasource. |
-| keycloak.unsupported.podTemplate         | string | `nil` | You can configure values that will be merged with the one configured by default by the operator. |
-| nameOverride                             | string | `""` |  |
-| operator.affinity                        | object | `{}` | Affinity for Operator Deployment. |
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| fullnameOverride | string | `""` |  |
+| imagePullSecrets | list | `[]` |  |
+| keycloak.additionalOptions | string | `nil` | Configuration of the Keycloak server expressed as a keys and values that can be either direct values or references to secrets. |
+| keycloak.db.database | string | `nil` | Sets the database name of the default JDBC URL of the chosen vendor. If the `url` option is set, this option is ignored. |
+| keycloak.db.host | string | `nil` | Sets the hostname of the default JDBC URL of the chosen vendor. If the `url` option is set, this option is ignored. |
+| keycloak.db.passwordSecret | string | `nil` | The reference to a secret holding the password of the database user. |
+| keycloak.db.poolInitialSize | string | `nil` | The initial size of the connection pool. |
+| keycloak.db.poolMaxSize | string | `nil` | The maximum size of the connection pool. |
+| keycloak.db.poolMinSize | string | `nil` | The minimal size of the connection pool. |
+| keycloak.db.port | string | `nil` | Sets the port of the default JDBC URL of the chosen vendor. If the `url` option is set, this option is ignored. |
+| keycloak.db.schema | string | `nil` | The database schema to be used. |
+| keycloak.db.url | string | `nil` | The full database JDBC URL. If not provided, a default URL is set based on the selected database vendor. |
+| keycloak.db.usernameSecret | string | `nil` | The reference to a secret holding the username of the database user. |
+| keycloak.db.vendor | string | `nil` | The database vendor. |
+| keycloak.enabled | bool | `false` | Enable deploying a bundled keycloak with the operator |
+| keycloak.features | object | see [Keycloak docs](https://www.keycloak.org/server/features) | Configure Keycloak features |
+| keycloak.features.disabled | list | `[]` | Disabled Keycloak features |
+| keycloak.features.enabled | list | `[]` | Enabled Keycloak features |
+| keycloak.hostname.admin | string | `nil` | The hostname for accessing the administration console. |
+| keycloak.hostname.adminUrl | string | `nil` | Set the base URL for accessing the administration console. |
+| keycloak.hostname.hostname | string | Disabled if not set. | Hostname for the Keycloak server. |
+| keycloak.hostname.strict | bool | `false` | Disables dynamically resolving the hostname from request headers |
+| keycloak.hostname.strictBackchannel | bool | `true` | By default backchannel URLs are dynamically resolved from request headers to allow internal and external applications. |
+| keycloak.http.httpEnabled | bool | `true` | Enable a HTTP listener |
+| keycloak.http.httpPort | string | `nil` | The used HTTP port |
+| keycloak.http.httpsPort | string | `nil` | The used HTTPS port |
+| keycloak.http.tlsSecret | string | `nil` | A secret containing the TLS configuration for HTTPS. |
+| keycloak.image.repository | string | `""` | Overrides the operator.keycloakImage.image value whose default is quay.io/keycloak/keycloak |
+| keycloak.image.tag | string | `""` | Overrides the operator.keycloakImage.tag value whose default is the chart appVersion. |
+| keycloak.imagePullSecrets | string | `nil` | Secret(s) that might be used when pulling an image from a private container image registry or repository. |
+| keycloak.ingress.annotations | list | `[]` | Annotations for the Ingress |
+| keycloak.ingress.className | string | `""` | Ingress class name |
+| keycloak.ingress.enabled | bool | `true` | The deployment is, by default, exposed through a basic ingress. |
+| keycloak.instances | int | `1` | Number of Keycloak instances in HA mode. |
+| keycloak.realmimport.enabled | bool | `false` | Deploy realmimport resources |
+| keycloak.realmimport.realms | list | `[]` | A list of realms to configure using the realmimport CRD. |
+| keycloak.transaction.xaEnabled | bool | `false` | Determine whether Keycloak should use a non-XA datasource. |
+| keycloak.unsupported.podTemplate | string | `nil` | You can configure values that will be merged with the one configured by default by the operator. |
+| nameOverride | string | `""` |  |
+| operator.affinity | object | `{}` | Affinity for Operator Deployment. |
 | operator.config.keycloakImage.repository | string | `"quay.io/keycloak/keycloak"` | Default keycloak image to use if non was specified in the Keycloak CRD. |
-| operator.config.keycloakImage.tag        | string | `""` |  |
-| operator.enabled                         | bool | `false` | Enable deploying the operator |
-| operator.image.pullPolicy                | string | `"IfNotPresent"` | Pull policy for Operator. |
-| operator.image.repository                | string | `"quay.io/keycloak/keycloak-operator"` | Operator Image source. |
-| operator.image.tag                       | string | `""` |  |
-| operator.nodeSelector                    | object | `{}` | Node selector for Operator Deployment. |
-| operator.podAnnotations                  | object | `{}` | Annotations to set on the Operator Deployment. |
-| operator.podSecurityContext              | object | `{}` | Pod security group configuration for Operator Deployment. |
-| operator.podTopologySpreadConstraints    | object | `{}` | Pod Topology Spread Constraints for Operator Deployment |
-| operator.replicaCount                    | int | `1` | Number or oeprator pods to start. |
-| operator.resources                       | object | `{}` | Resource requests and limits for Operator Deployment. |
-| operator.securityContext                 | object | `{}` | Security context for Operator Deployment. |
-| operator.service.enabled                 | bool | `true` | Enable creation of Service |
-| operator.service.port                    | int | `8080` | Service port for Operator. |
-| operator.service.type                    | string | `"ClusterIP"` | Service type for Operator. |
-| operator.serviceAccount.annotations      | object | `{}` | Annotations to add to the service account |
-| operator.serviceAccount.create           | bool | `true` | Specifies whether a service account should be created. |
-| operator.serviceAccount.name             | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
-| operator.tolerations                     | list | `[]` | Tolerations for Operator Deployment. |
+| operator.config.keycloakImage.tag | string | `""` |  |
+| operator.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for Operator. |
+| operator.image.repository | string | `"quay.io/keycloak/keycloak-operator"` | Operator Image source. |
+| operator.image.tag | string | `""` |  |
+| operator.nodeSelector | object | `{}` | Node selector for Operator Deployment. |
+| operator.podAnnotations | object | `{}` | Annotations to set on the Operator Deployment. |
+| operator.podSecurityContext | object | `{}` | Pod security group configuration for Operator Deployment. |
+| operator.podTopologySpreadConstraints | object | `{}` | Pod Topology Spread Constraints for Operator Deployment |
+| operator.replicaCount | int | `1` | Number or oeprator pods to start. |
+| operator.resources | object | `{}` | Resource requests and limits for Operator Deployment. |
+| operator.securityContext | object | `{}` | Security context for Operator Deployment. |
+| operator.service.enabled | bool | `true` | Enable creation of Service |
+| operator.service.port | int | `8080` | Service port for Operator. |
+| operator.service.type | string | `"ClusterIP"` | Service type for Operator. |
+| operator.serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
+| operator.serviceAccount.create | bool | `true` | Specifies whether a service account should be created. |
+| operator.serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
+| operator.tolerations | list | `[]` | Tolerations for Operator Deployment. |
 
 ## About this chart
 

--- a/charts/keycloak-operator/README.md
+++ b/charts/keycloak-operator/README.md
@@ -16,67 +16,68 @@ This chart is maintained by [Adfinis](https://adfinis.com/?pk_campaign=github&pk
 
 ## Values
 
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-| fullnameOverride | string | `""` |  |
-| imagePullSecrets | list | `[]` |  |
-| keycloak.additionalOptions | string | `nil` | Configuration of the Keycloak server expressed as a keys and values that can be either direct values or references to secrets. |
-| keycloak.db.database | string | `nil` | Sets the database name of the default JDBC URL of the chosen vendor. If the `url` option is set, this option is ignored. |
-| keycloak.db.host | string | `nil` | Sets the hostname of the default JDBC URL of the chosen vendor. If the `url` option is set, this option is ignored. |
-| keycloak.db.passwordSecret | string | `nil` | The reference to a secret holding the password of the database user. |
-| keycloak.db.poolInitialSize | string | `nil` | The initial size of the connection pool. |
-| keycloak.db.poolMaxSize | string | `nil` | The maximum size of the connection pool. |
-| keycloak.db.poolMinSize | string | `nil` | The minimal size of the connection pool. |
-| keycloak.db.port | string | `nil` | Sets the port of the default JDBC URL of the chosen vendor. If the `url` option is set, this option is ignored. |
-| keycloak.db.schema | string | `nil` | The database schema to be used. |
-| keycloak.db.url | string | `nil` | The full database JDBC URL. If not provided, a default URL is set based on the selected database vendor. |
-| keycloak.db.usernameSecret | string | `nil` | The reference to a secret holding the username of the database user. |
-| keycloak.db.vendor | string | `nil` | The database vendor. |
-| keycloak.enabled | bool | `false` | Enable deploying a bundled keycloak with the operator |
-| keycloak.features | object | see [Keycloak docs](https://www.keycloak.org/server/features) | Configure Keycloak features |
-| keycloak.features.disabled | list | `[]` | Disabled Keycloak features |
-| keycloak.features.enabled | list | `[]` | Enabled Keycloak features |
-| keycloak.hostname.admin | string | `nil` | The hostname for accessing the administration console. |
-| keycloak.hostname.adminUrl | string | `nil` | Set the base URL for accessing the administration console. |
-| keycloak.hostname.hostname | string | Disabled if not set. | Hostname for the Keycloak server. |
-| keycloak.hostname.strict | bool | `false` | Disables dynamically resolving the hostname from request headers |
-| keycloak.hostname.strictBackchannel | bool | `true` | By default backchannel URLs are dynamically resolved from request headers to allow internal and external applications. |
-| keycloak.http.httpEnabled | bool | `true` | Enable a HTTP listener |
-| keycloak.http.httpPort | string | `nil` | The used HTTP port |
-| keycloak.http.httpsPort | string | `nil` | The used HTTPS port |
-| keycloak.http.tlsSecret | string | `nil` | A secret containing the TLS configuration for HTTPS. |
-| keycloak.image.repository | string | `""` | Overrides the operator.keycloakImage.image value whose default is quay.io/keycloak/keycloak |
-| keycloak.image.tag | string | `""` | Overrides the operator.keycloakImage.tag value whose default is the chart appVersion. |
-| keycloak.imagePullSecrets | string | `nil` | Secret(s) that might be used when pulling an image from a private container image registry or repository. |
-| keycloak.ingress.annotations | list | `[]` | Annotations for the Ingress |
-| keycloak.ingress.className | string | `""` | Ingress class name |
-| keycloak.ingress.enabled | bool | `true` | The deployment is, by default, exposed through a basic ingress. |
-| keycloak.instances | int | `1` | Number of Keycloak instances in HA mode. |
-| keycloak.realmimport.enabled | bool | `false` | Deploy realmimport resources |
-| keycloak.realmimport.realms | list | `[]` | A list of realms to configure using the realmimport CRD. |
-| keycloak.transaction.xaEnabled | bool | `false` | Determine whether Keycloak should use a non-XA datasource. |
-| keycloak.unsupported.podTemplate | string | `nil` | You can configure values that will be merged with the one configured by default by the operator. |
-| nameOverride | string | `""` |  |
-| operator.affinity | object | `{}` | Affinity for Operator Deployment. |
+| Key                                      | Type | Default | Description |
+|------------------------------------------|------|---------|-------------|
+| fullnameOverride                         | string | `""` |  |
+| imagePullSecrets                         | list | `[]` |  |
+| keycloak.additionalOptions               | string | `nil` | Configuration of the Keycloak server expressed as a keys and values that can be either direct values or references to secrets. |
+| keycloak.db.database                     | string | `nil` | Sets the database name of the default JDBC URL of the chosen vendor. If the `url` option is set, this option is ignored. |
+| keycloak.db.host                         | string | `nil` | Sets the hostname of the default JDBC URL of the chosen vendor. If the `url` option is set, this option is ignored. |
+| keycloak.db.passwordSecret               | string | `nil` | The reference to a secret holding the password of the database user. |
+| keycloak.db.poolInitialSize              | string | `nil` | The initial size of the connection pool. |
+| keycloak.db.poolMaxSize                  | string | `nil` | The maximum size of the connection pool. |
+| keycloak.db.poolMinSize                  | string | `nil` | The minimal size of the connection pool. |
+| keycloak.db.port                         | string | `nil` | Sets the port of the default JDBC URL of the chosen vendor. If the `url` option is set, this option is ignored. |
+| keycloak.db.schema                       | string | `nil` | The database schema to be used. |
+| keycloak.db.url                          | string | `nil` | The full database JDBC URL. If not provided, a default URL is set based on the selected database vendor. |
+| keycloak.db.usernameSecret               | string | `nil` | The reference to a secret holding the username of the database user. |
+| keycloak.db.vendor                       | string | `nil` | The database vendor. |
+| keycloak.enabled                         | bool | `false` | Enable deploying a bundled keycloak with the operator |
+| keycloak.features                        | object | see [Keycloak docs](https://www.keycloak.org/server/features) | Configure Keycloak features |
+| keycloak.features.disabled               | list | `[]` | Disabled Keycloak features |
+| keycloak.features.enabled                | list | `[]` | Enabled Keycloak features |
+| keycloak.hostname.admin                  | string | `nil` | The hostname for accessing the administration console. |
+| keycloak.hostname.adminUrl               | string | `nil` | Set the base URL for accessing the administration console. |
+| keycloak.hostname.hostname               | string | Disabled if not set. | Hostname for the Keycloak server. |
+| keycloak.hostname.strict                 | bool | `false` | Disables dynamically resolving the hostname from request headers |
+| keycloak.hostname.strictBackchannel      | bool | `true` | By default backchannel URLs are dynamically resolved from request headers to allow internal and external applications. |
+| keycloak.http.httpEnabled                | bool | `true` | Enable a HTTP listener |
+| keycloak.http.httpPort                   | string | `nil` | The used HTTP port |
+| keycloak.http.httpsPort                  | string | `nil` | The used HTTPS port |
+| keycloak.http.tlsSecret                  | string | `nil` | A secret containing the TLS configuration for HTTPS. |
+| keycloak.image.repository                | string | `""` | Overrides the operator.keycloakImage.image value whose default is quay.io/keycloak/keycloak |
+| keycloak.image.tag                       | string | `""` | Overrides the operator.keycloakImage.tag value whose default is the chart appVersion. |
+| keycloak.imagePullSecrets                | string | `nil` | Secret(s) that might be used when pulling an image from a private container image registry or repository. |
+| keycloak.ingress.annotations             | list | `[]` | Annotations for the Ingress |
+| keycloak.ingress.className               | string | `""` | Ingress class name |
+| keycloak.ingress.enabled                 | bool | `true` | The deployment is, by default, exposed through a basic ingress. |
+| keycloak.instances                       | int | `1` | Number of Keycloak instances in HA mode. |
+| keycloak.realmimport.enabled             | bool | `false` | Deploy realmimport resources |
+| keycloak.realmimport.realms              | list | `[]` | A list of realms to configure using the realmimport CRD. |
+| keycloak.transaction.xaEnabled           | bool | `false` | Determine whether Keycloak should use a non-XA datasource. |
+| keycloak.unsupported.podTemplate         | string | `nil` | You can configure values that will be merged with the one configured by default by the operator. |
+| nameOverride                             | string | `""` |  |
+| operator.affinity                        | object | `{}` | Affinity for Operator Deployment. |
 | operator.config.keycloakImage.repository | string | `"quay.io/keycloak/keycloak"` | Default keycloak image to use if non was specified in the Keycloak CRD. |
-| operator.config.keycloakImage.tag | string | `""` |  |
-| operator.image.pullPolicy | string | `"IfNotPresent"` | Pull policy for Operator. |
-| operator.image.repository | string | `"quay.io/keycloak/keycloak-operator"` | Operator Image source. |
-| operator.image.tag | string | `""` |  |
-| operator.nodeSelector | object | `{}` | Node selector for Operator Deployment. |
-| operator.podAnnotations | object | `{}` | Annotations to set on the Operator Deployment. |
-| operator.podSecurityContext | object | `{}` | Pod security group configuration for Operator Deployment. |
-| operator.podTopologySpreadConstraints | object | `{}` | Pod Topology Spread Constraints for Operator Deployment |
-| operator.replicaCount | int | `1` | Number or oeprator pods to start. |
-| operator.resources | object | `{}` | Resource requests and limits for Operator Deployment. |
-| operator.securityContext | object | `{}` | Security context for Operator Deployment. |
-| operator.service.enabled | bool | `true` | Enable creation of Service |
-| operator.service.port | int | `8080` | Service port for Operator. |
-| operator.service.type | string | `"ClusterIP"` | Service type for Operator. |
-| operator.serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
-| operator.serviceAccount.create | bool | `true` | Specifies whether a service account should be created. |
-| operator.serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
-| operator.tolerations | list | `[]` | Tolerations for Operator Deployment. |
+| operator.config.keycloakImage.tag        | string | `""` |  |
+| operator.enabled                         | bool | `false` | Enable deploying the operator |
+| operator.image.pullPolicy                | string | `"IfNotPresent"` | Pull policy for Operator. |
+| operator.image.repository                | string | `"quay.io/keycloak/keycloak-operator"` | Operator Image source. |
+| operator.image.tag                       | string | `""` |  |
+| operator.nodeSelector                    | object | `{}` | Node selector for Operator Deployment. |
+| operator.podAnnotations                  | object | `{}` | Annotations to set on the Operator Deployment. |
+| operator.podSecurityContext              | object | `{}` | Pod security group configuration for Operator Deployment. |
+| operator.podTopologySpreadConstraints    | object | `{}` | Pod Topology Spread Constraints for Operator Deployment |
+| operator.replicaCount                    | int | `1` | Number or oeprator pods to start. |
+| operator.resources                       | object | `{}` | Resource requests and limits for Operator Deployment. |
+| operator.securityContext                 | object | `{}` | Security context for Operator Deployment. |
+| operator.service.enabled                 | bool | `true` | Enable creation of Service |
+| operator.service.port                    | int | `8080` | Service port for Operator. |
+| operator.service.type                    | string | `"ClusterIP"` | Service type for Operator. |
+| operator.serviceAccount.annotations      | object | `{}` | Annotations to add to the service account |
+| operator.serviceAccount.create           | bool | `true` | Specifies whether a service account should be created. |
+| operator.serviceAccount.name             | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
+| operator.tolerations                     | list | `[]` | Tolerations for Operator Deployment. |
 
 ## About this chart
 

--- a/charts/keycloak-operator/ci/default-values.yaml
+++ b/charts/keycloak-operator/ci/default-values.yaml
@@ -1,4 +1,3 @@
 operator:
+  enabled: true
   replicaCount: 1
-keycloak:
-  enabled: false

--- a/charts/keycloak-operator/ci/operand-values.yaml
+++ b/charts/keycloak-operator/ci/operand-values.yaml
@@ -1,5 +1,3 @@
-operator:
-  replicaCount: 1
 keycloak:
   enabled: true
   name: keycloak

--- a/charts/keycloak-operator/templates/NOTES.txt
+++ b/charts/keycloak-operator/templates/NOTES.txt
@@ -1,7 +1,9 @@
-1. The Operator has been deployed, view the logs by running this command:
+{{- if .Values.operator.enabled }}
+- The Operator has been deployed, view the logs by running this command:
   kubectl --namespace {{ .Release.Namespace }} logs deployment/{{ include "keycloak-operator.operator.fullname" . }}
+{{- end }}
 {{- if .Values.keycloak.enabled }}
-2. A Keycloak instance has been deployed, connect to it at "{{ .Values.keycloak.hostname.hostname }}"
+- A Keycloak instance has been deployed, connect to it at "{{ .Values.keycloak.hostname.hostname }}"
 {{- if .Values.keycloak.realmimport.enabled }}
    Additionally the following realms have been imported:
    {{- range .Values.keycloak.realmimport.realms }}

--- a/charts/keycloak-operator/templates/operator/clusterrole.yaml
+++ b/charts/keycloak-operator/templates/operator/clusterrole.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.operator.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -41,3 +42,4 @@ rules:
       - delete
       - patch
       - update
+{{- end }}

--- a/charts/keycloak-operator/templates/operator/deployment.yaml
+++ b/charts/keycloak-operator/templates/operator/deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.operator.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -80,3 +81,4 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+{{- end }}

--- a/charts/keycloak-operator/templates/operator/rolebinding.yaml
+++ b/charts/keycloak-operator/templates/operator/rolebinding.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.operator.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -53,3 +54,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ include "keycloak-operator.operator.serviceAccountName" . }}
+{{- end }}

--- a/charts/keycloak-operator/templates/operator/roles.yaml
+++ b/charts/keycloak-operator/templates/operator/roles.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.operator.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -56,3 +57,4 @@ rules:
       - delete
       - patch
       - update
+{{- end }}

--- a/charts/keycloak-operator/templates/operator/service.yaml
+++ b/charts/keycloak-operator/templates/operator/service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.operator.enabled }}
 {{- if .Values.operator.service.enabled }}
 apiVersion: v1
 kind: Service
@@ -14,4 +15,5 @@ spec:
       name: http
   selector:
     {{- include "keycloak-operator.operator.selectorLabels" . | nindent 4 }}
+{{- end }}
 {{- end }}

--- a/charts/keycloak-operator/templates/operator/serviceaccount.yaml
+++ b/charts/keycloak-operator/templates/operator/serviceaccount.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.operator.enabled }}
 {{- if .Values.operator.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
@@ -9,4 +10,5 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/keycloak-operator/tests/__snapshot__/default_test.yaml.snap
+++ b/charts/keycloak-operator/tests/__snapshot__/default_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: keycloak-operator
         app.kubernetes.io/version: 24.0.4
-        helm.sh/chart: keycloak-operator-1.1.0
+        helm.sh/chart: keycloak-operator-1.2.0
       name: keycloakcontroller-cluster-role
     rules:
       - apiGroups:
@@ -36,7 +36,7 @@ should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: keycloak-operator
         app.kubernetes.io/version: 24.0.4
-        helm.sh/chart: keycloak-operator-1.1.0
+        helm.sh/chart: keycloak-operator-1.2.0
       name: keycloakrealmimportcontroller-cluster-role
     rules:
       - apiGroups:
@@ -63,7 +63,7 @@ should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: keycloak-operator
         app.kubernetes.io/version: 24.0.4
-        helm.sh/chart: keycloak-operator-1.1.0
+        helm.sh/chart: keycloak-operator-1.2.0
       name: RELEASE-NAME-keycloak-operator-operator
     spec:
       replicas: 1
@@ -128,7 +128,7 @@ should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: keycloak-operator
         app.kubernetes.io/version: 24.0.4
-        helm.sh/chart: keycloak-operator-1.1.0
+        helm.sh/chart: keycloak-operator-1.2.0
       name: keycloak-operator-role-binding
     roleRef:
       apiGroup: rbac.authorization.k8s.io
@@ -147,7 +147,7 @@ should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: keycloak-operator
         app.kubernetes.io/version: 24.0.4
-        helm.sh/chart: keycloak-operator-1.1.0
+        helm.sh/chart: keycloak-operator-1.2.0
       name: keycloak-operator-view
     roleRef:
       apiGroup: rbac.authorization.k8s.io
@@ -166,7 +166,7 @@ should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: keycloak-operator
         app.kubernetes.io/version: 24.0.4
-        helm.sh/chart: keycloak-operator-1.1.0
+        helm.sh/chart: keycloak-operator-1.2.0
       name: keycloakcontroller-role-binding
     roleRef:
       apiGroup: rbac.authorization.k8s.io
@@ -185,7 +185,7 @@ should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: keycloak-operator
         app.kubernetes.io/version: 24.0.4
-        helm.sh/chart: keycloak-operator-1.1.0
+        helm.sh/chart: keycloak-operator-1.2.0
       name: keycloakrealmimportcontroller-role-binding
     roleRef:
       apiGroup: rbac.authorization.k8s.io
@@ -204,7 +204,7 @@ should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: keycloak-operator
         app.kubernetes.io/version: 24.0.4
-        helm.sh/chart: keycloak-operator-1.1.0
+        helm.sh/chart: keycloak-operator-1.2.0
       name: keycloak-operator-role
     rules:
       - apiGroups:
@@ -267,7 +267,7 @@ should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: keycloak-operator
         app.kubernetes.io/version: 24.0.4
-        helm.sh/chart: keycloak-operator-1.1.0
+        helm.sh/chart: keycloak-operator-1.2.0
       name: RELEASE-NAME-keycloak-operator-operator
     spec:
       ports:
@@ -290,5 +290,5 @@ should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: keycloak-operator
         app.kubernetes.io/version: 24.0.4
-        helm.sh/chart: keycloak-operator-1.1.0
+        helm.sh/chart: keycloak-operator-1.2.0
       name: RELEASE-NAME-keycloak-operator

--- a/charts/keycloak-operator/tests/__snapshot__/operand_test.yaml.snap
+++ b/charts/keycloak-operator/tests/__snapshot__/operand_test.yaml.snap
@@ -7,7 +7,7 @@ should match snapshot:
         app.kubernetes.io/component: keycloak
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/version: 24.0.4
-        helm.sh/chart: keycloak-operator-1.1.0
+        helm.sh/chart: keycloak-operator-1.2.0
       name: keycloak
     spec:
       features:
@@ -35,7 +35,7 @@ should match snapshot:
       labels:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/version: 24.0.4
-        helm.sh/chart: keycloak-operator-1.1.0
+        helm.sh/chart: keycloak-operator-1.2.0
       name: RELEASE-NAME-keycloak-operator-test
     spec:
       keycloakCRName: keycloak


### PR DESCRIPTION
# Description
Included property for disabling operator templates generation, same procedure as the one already available for enabling/disabling keycloak templates.

# Issues
https://github.com/adfinis/helm-charts/issues/1270

# Checklist
* [X] This PR contains a description of the changes I'm making
* [X] I updated the version in Chart.yaml
* [X] I updated the changelog with an `artifacthub.io/changes` annotation in `Chart.yaml`, check the [example](docs/development.md#Changelog) in the documentation.
* [X] I updated applicable README.md files using  `pre-commit run`
* [X] I documented any high-level concepts I'm introducing in `docs/`
* [x] CI is currently green and this is ready for review
* [X] I am ready to test changes after they are applied and released

<!--
    Please open PRs as Draft while you make CI green and/or finalise
    documentation. Your PR will be assigned to a CODEOWNER once you mark it
    as "Ready for Review".

   Once it is approved we will squash your changes onto the default branch
   and our trusty bot account will release them to the repository.
-->
