### PR TITLE
fix: change from operator. to kc.operator. keys

### DIFF
--- a/charts/keycloak-operator/Chart.yaml
+++ b/charts/keycloak-operator/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: keycloak-operator
 description: Deploy Keycloak Operator and Keycloak
 type: application
-version: 1.2.0
+version: 1.2.1
 appVersion: "24.0.4"
 icon: https://www.keycloak.org/resources/images/logo-stacked.svg
 home: https://www.keycloak.org

--- a/charts/keycloak-operator/Chart.yaml
+++ b/charts/keycloak-operator/Chart.yaml
@@ -16,7 +16,4 @@ maintainers:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "New feature: disable Operator templates generation"
-      links:
-        - name: "Issue 1270"
-          url: https://github.com/adfinis/helm-charts/issues/1270
+      description: "Fix: change from operator. to kc.operator. keys"

--- a/charts/keycloak-operator/README.md
+++ b/charts/keycloak-operator/README.md
@@ -1,6 +1,6 @@
 # keycloak-operator
 
-![Version: 1.2.0](https://img.shields.io/badge/Version-1.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 24.0.4](https://img.shields.io/badge/AppVersion-24.0.4-informational?style=flat-square)
+![Version: 1.2.1](https://img.shields.io/badge/Version-1.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 24.0.4](https://img.shields.io/badge/AppVersion-24.0.4-informational?style=flat-square)
 
 Deploy Keycloak Operator and Keycloak
 

--- a/charts/keycloak-operator/templates/operator/deployment.yaml
+++ b/charts/keycloak-operator/templates/operator/deployment.yaml
@@ -37,7 +37,7 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-            - name: OPERATOR_KEYCLOAK_IMAGE
+            - name: KC_OPERATOR_KEYCLOAK_IMAGE
               value: "{{ .Values.operator.config.keycloakImage.repository }}:{{ .Values.operator.config.keycloakImage.tag | default .Chart.AppVersion }}"
           ports:
             - name: http

--- a/charts/keycloak-operator/tests/__snapshot__/default_test.yaml.snap
+++ b/charts/keycloak-operator/tests/__snapshot__/default_test.yaml.snap
@@ -85,7 +85,7 @@ should match snapshot:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.namespace
-                - name: OPERATOR_KEYCLOAK_IMAGE
+                - name: KC_OPERATOR_KEYCLOAK_IMAGE
                   value: quay.io/keycloak/keycloak:24.0.4
               image: quay.io/keycloak/keycloak-operator:24.0.4
               imagePullPolicy: IfNotPresent

--- a/charts/keycloak-operator/tests/__snapshot__/default_test.yaml.snap
+++ b/charts/keycloak-operator/tests/__snapshot__/default_test.yaml.snap
@@ -9,7 +9,7 @@ should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: keycloak-operator
         app.kubernetes.io/version: 24.0.4
-        helm.sh/chart: keycloak-operator-1.2.0
+        helm.sh/chart: keycloak-operator-1.2.1
       name: keycloakcontroller-cluster-role
     rules:
       - apiGroups:
@@ -36,7 +36,7 @@ should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: keycloak-operator
         app.kubernetes.io/version: 24.0.4
-        helm.sh/chart: keycloak-operator-1.2.0
+        helm.sh/chart: keycloak-operator-1.2.1
       name: keycloakrealmimportcontroller-cluster-role
     rules:
       - apiGroups:
@@ -63,7 +63,7 @@ should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: keycloak-operator
         app.kubernetes.io/version: 24.0.4
-        helm.sh/chart: keycloak-operator-1.2.0
+        helm.sh/chart: keycloak-operator-1.2.1
       name: RELEASE-NAME-keycloak-operator-operator
     spec:
       replicas: 1
@@ -128,7 +128,7 @@ should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: keycloak-operator
         app.kubernetes.io/version: 24.0.4
-        helm.sh/chart: keycloak-operator-1.2.0
+        helm.sh/chart: keycloak-operator-1.2.1
       name: keycloak-operator-role-binding
     roleRef:
       apiGroup: rbac.authorization.k8s.io
@@ -147,7 +147,7 @@ should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: keycloak-operator
         app.kubernetes.io/version: 24.0.4
-        helm.sh/chart: keycloak-operator-1.2.0
+        helm.sh/chart: keycloak-operator-1.2.1
       name: keycloak-operator-view
     roleRef:
       apiGroup: rbac.authorization.k8s.io
@@ -166,7 +166,7 @@ should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: keycloak-operator
         app.kubernetes.io/version: 24.0.4
-        helm.sh/chart: keycloak-operator-1.2.0
+        helm.sh/chart: keycloak-operator-1.2.1
       name: keycloakcontroller-role-binding
     roleRef:
       apiGroup: rbac.authorization.k8s.io
@@ -185,7 +185,7 @@ should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: keycloak-operator
         app.kubernetes.io/version: 24.0.4
-        helm.sh/chart: keycloak-operator-1.2.0
+        helm.sh/chart: keycloak-operator-1.2.1
       name: keycloakrealmimportcontroller-role-binding
     roleRef:
       apiGroup: rbac.authorization.k8s.io
@@ -204,7 +204,7 @@ should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: keycloak-operator
         app.kubernetes.io/version: 24.0.4
-        helm.sh/chart: keycloak-operator-1.2.0
+        helm.sh/chart: keycloak-operator-1.2.1
       name: keycloak-operator-role
     rules:
       - apiGroups:
@@ -267,7 +267,7 @@ should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: keycloak-operator
         app.kubernetes.io/version: 24.0.4
-        helm.sh/chart: keycloak-operator-1.2.0
+        helm.sh/chart: keycloak-operator-1.2.1
       name: RELEASE-NAME-keycloak-operator-operator
     spec:
       ports:
@@ -290,5 +290,5 @@ should match snapshot:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: keycloak-operator
         app.kubernetes.io/version: 24.0.4
-        helm.sh/chart: keycloak-operator-1.2.0
+        helm.sh/chart: keycloak-operator-1.2.1
       name: RELEASE-NAME-keycloak-operator

--- a/charts/keycloak-operator/tests/__snapshot__/operand_test.yaml.snap
+++ b/charts/keycloak-operator/tests/__snapshot__/operand_test.yaml.snap
@@ -7,7 +7,7 @@ should match snapshot:
         app.kubernetes.io/component: keycloak
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/version: 24.0.4
-        helm.sh/chart: keycloak-operator-1.2.0
+        helm.sh/chart: keycloak-operator-1.2.1
       name: keycloak
     spec:
       features:
@@ -35,7 +35,7 @@ should match snapshot:
       labels:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/version: 24.0.4
-        helm.sh/chart: keycloak-operator-1.2.0
+        helm.sh/chart: keycloak-operator-1.2.1
       name: RELEASE-NAME-keycloak-operator-test
     spec:
       keycloakCRName: keycloak


### PR DESCRIPTION

# Description
fix: change from operator. to kc.operator. keys

Keycloak Operator change:
https://github.com/keycloak/keycloak/commit/77581d25278b6819a5cbc802943764557a366c2f
https://github.com/keycloak/keycloak/pull/26414

Source code:
https://github.com/keycloak/keycloak/blob/release/24.0/operator/src/main/resources/application.properties#L8


# Issues
Operator use  be default keycloak nightly version, because environment variable `OPERATOR_KEYCLOAK_IMAGE` was renamed to `KC_OPERATOR_KEYCLOAK_IMAGE`.

# Checklist
* [ ] This PR contains a description of the changes I'm making
* [ ] I updated the version in Chart.yaml
* [ ] I updated the changelog with an `artifacthub.io/changes` annotation in `Chart.yaml`, check the [example](docs/development.md#Changelog) in the documentation.
* [ ] I updated applicable README.md files using  `pre-commit run`
* [ ] I documented any high-level concepts I'm introducing in `docs/`
* [ ] CI is currently green and this is ready for review
* [ X] I am ready to test changes after they are applied and released
