### PR TITLE
fix: optional backchannelDynamic and update to 25.0.4

### DIFF
--- a/charts/keycloak-operator/Chart.yaml
+++ b/charts/keycloak-operator/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: keycloak-operator
 description: Deploy Keycloak Operator and Keycloak
 type: application
-version: 1.3.0
-appVersion: "25.0.0"
+version: 1.3.1
+appVersion: "25.0.4"
 icon: https://www.keycloak.org/resources/images/logo-stacked.svg
 home: https://www.keycloak.org
 sources:
@@ -16,9 +16,9 @@ maintainers:
 annotations:
   artifacthub.io/changes: |
     - kind: changed
-      description: "feat: Update to Keycloak 25.0.0"
+      description: "fix: Update to Keycloak 25.0.4"
       links:
-        - name: Keycloak 25.0.0
-          url: https://www.keycloak.org/2024/06/keycloak-2500-released
+        - name: Keycloak 25.0.4
+          url: https://www.keycloak.org/2024/08/keycloak-2504-released
     - kind: changed
-      description: "fix: Update operator CRDs"
+      description: "fix: Make .backchannelDynamic flag truly optional"

--- a/charts/keycloak-operator/README.md
+++ b/charts/keycloak-operator/README.md
@@ -1,6 +1,6 @@
 # keycloak-operator
 
-![Version: 1.3.0](https://img.shields.io/badge/Version-1.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 25.0.0](https://img.shields.io/badge/AppVersion-25.0.0-informational?style=flat-square)
+![Version: 1.3.1](https://img.shields.io/badge/Version-1.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 25.0.4](https://img.shields.io/badge/AppVersion-25.0.4-informational?style=flat-square)
 
 Deploy Keycloak Operator and Keycloak
 

--- a/charts/keycloak-operator/templates/keycloak/keycloak.yaml
+++ b/charts/keycloak-operator/templates/keycloak/keycloak.yaml
@@ -66,8 +66,8 @@ spec:
     {{- with .adminUrl }}
     adminUrl:  {{ . }}
     {{- end }}
-    {{- if not (.backchannelDynamic | toString | empty) }}
-    backchannelDynamic: {{ ternary "true"  "false" .backchannelDynamic }}
+    {{- if not (eq .backchannelDynamic nil) }}
+    backchannelDynamic: {{ .backchannelDynamic  }}
     {{- end }}
     {{- with .hostname }}
     hostname: {{ . | quote }}

--- a/charts/keycloak-operator/tests/__snapshot__/default_test.yaml.snap
+++ b/charts/keycloak-operator/tests/__snapshot__/default_test.yaml.snap
@@ -8,8 +8,8 @@ should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: keycloak-operator
-        app.kubernetes.io/version: 25.0.0
-        helm.sh/chart: keycloak-operator-1.3.0
+        app.kubernetes.io/version: 25.0.4
+        helm.sh/chart: keycloak-operator-1.3.1
       name: keycloakcontroller-cluster-role
     rules:
       - apiGroups:
@@ -35,8 +35,8 @@ should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: keycloak-operator
-        app.kubernetes.io/version: 25.0.0
-        helm.sh/chart: keycloak-operator-1.3.0
+        app.kubernetes.io/version: 25.0.4
+        helm.sh/chart: keycloak-operator-1.3.1
       name: keycloakrealmimportcontroller-cluster-role
     rules:
       - apiGroups:
@@ -62,8 +62,8 @@ should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: keycloak-operator
-        app.kubernetes.io/version: 25.0.0
-        helm.sh/chart: keycloak-operator-1.3.0
+        app.kubernetes.io/version: 25.0.4
+        helm.sh/chart: keycloak-operator-1.3.1
       name: RELEASE-NAME-keycloak-operator-operator
     spec:
       replicas: 1
@@ -86,8 +86,8 @@ should match snapshot:
                     fieldRef:
                       fieldPath: metadata.namespace
                 - name: KC_OPERATOR_KEYCLOAK_IMAGE
-                  value: quay.io/keycloak/keycloak:25.0.0
-              image: quay.io/keycloak/keycloak-operator:25.0.0
+                  value: quay.io/keycloak/keycloak:25.0.4
+              image: quay.io/keycloak/keycloak-operator:25.0.4
               imagePullPolicy: IfNotPresent
               livenessProbe:
                 failureThreshold: 3
@@ -127,8 +127,8 @@ should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: keycloak-operator
-        app.kubernetes.io/version: 25.0.0
-        helm.sh/chart: keycloak-operator-1.3.0
+        app.kubernetes.io/version: 25.0.4
+        helm.sh/chart: keycloak-operator-1.3.1
       name: keycloak-operator-role-binding
     roleRef:
       apiGroup: rbac.authorization.k8s.io
@@ -146,8 +146,8 @@ should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: keycloak-operator
-        app.kubernetes.io/version: 25.0.0
-        helm.sh/chart: keycloak-operator-1.3.0
+        app.kubernetes.io/version: 25.0.4
+        helm.sh/chart: keycloak-operator-1.3.1
       name: keycloak-operator-view
     roleRef:
       apiGroup: rbac.authorization.k8s.io
@@ -165,8 +165,8 @@ should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: keycloak-operator
-        app.kubernetes.io/version: 25.0.0
-        helm.sh/chart: keycloak-operator-1.3.0
+        app.kubernetes.io/version: 25.0.4
+        helm.sh/chart: keycloak-operator-1.3.1
       name: keycloakcontroller-role-binding
     roleRef:
       apiGroup: rbac.authorization.k8s.io
@@ -184,8 +184,8 @@ should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: keycloak-operator
-        app.kubernetes.io/version: 25.0.0
-        helm.sh/chart: keycloak-operator-1.3.0
+        app.kubernetes.io/version: 25.0.4
+        helm.sh/chart: keycloak-operator-1.3.1
       name: keycloakrealmimportcontroller-role-binding
     roleRef:
       apiGroup: rbac.authorization.k8s.io
@@ -203,8 +203,8 @@ should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: keycloak-operator
-        app.kubernetes.io/version: 25.0.0
-        helm.sh/chart: keycloak-operator-1.3.0
+        app.kubernetes.io/version: 25.0.4
+        helm.sh/chart: keycloak-operator-1.3.1
       name: keycloak-operator-role
     rules:
       - apiGroups:
@@ -266,8 +266,8 @@ should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: keycloak-operator
-        app.kubernetes.io/version: 25.0.0
-        helm.sh/chart: keycloak-operator-1.3.0
+        app.kubernetes.io/version: 25.0.4
+        helm.sh/chart: keycloak-operator-1.3.1
       name: RELEASE-NAME-keycloak-operator-operator
     spec:
       ports:
@@ -289,6 +289,6 @@ should match snapshot:
         app.kubernetes.io/instance: RELEASE-NAME
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: keycloak-operator
-        app.kubernetes.io/version: 25.0.0
-        helm.sh/chart: keycloak-operator-1.3.0
+        app.kubernetes.io/version: 25.0.4
+        helm.sh/chart: keycloak-operator-1.3.1
       name: RELEASE-NAME-keycloak-operator

--- a/charts/keycloak-operator/tests/__snapshot__/operand_test.yaml.snap
+++ b/charts/keycloak-operator/tests/__snapshot__/operand_test.yaml.snap
@@ -6,8 +6,8 @@ should match snapshot:
       labels:
         app.kubernetes.io/component: keycloak
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/version: 25.0.0
-        helm.sh/chart: keycloak-operator-1.3.0
+        app.kubernetes.io/version: 25.0.4
+        helm.sh/chart: keycloak-operator-1.3.1
       name: keycloak
     spec:
       features:
@@ -33,8 +33,8 @@ should match snapshot:
     metadata:
       labels:
         app.kubernetes.io/managed-by: Helm
-        app.kubernetes.io/version: 25.0.0
-        helm.sh/chart: keycloak-operator-1.3.0
+        app.kubernetes.io/version: 25.0.4
+        helm.sh/chart: keycloak-operator-1.3.1
       name: RELEASE-NAME-keycloak-operator-test
     spec:
       keycloakCRName: keycloak


### PR DESCRIPTION
<!--
    Thank you for your contribution. Please use this template to help guide
    you towards preparing a PR that fullfills our merge requirements.
-->
# Description

Updates to the latest keycloak patch release and makes the backchannelDynamic flag truly optional.

# Issues

<!--
    Link related issues here, it's ok if this is empty but we do recommend that
    you create issues before working on PRs, issues on internal trackers are
    fine and need not be linked here.

    If your PR adds a new chart we expect you to create and link an issue so we
    can discuss adding your chart before you put the work into creating it.
-->

# Checklist

<!--
    Take care of the default items before marking your PR as ready for review,
    be prepared to add more items.
-->

* [x] This PR contains a description of the changes I'm making
* [x] I updated the version in Chart.yaml
* [x] I updated the changelog with an `artifacthub.io/changes` annotation in `Chart.yaml`, check the [example](docs/development.md#Changelog) in the documentation.
* [x] I updated applicable README.md files using  `pre-commit run`
* [x] I documented any high-level concepts I'm introducing in `docs/`
* [x] CI is currently green and this is ready for review
* [x] I am ready to test changes after they are applied and released

<!--
    Please open PRs as Draft while you make CI green and/or finalise
    documentation. Your PR will be assigned to a CODEOWNER once you mark it
    as "Ready for Review".

   Once it is approved we will squash your changes onto the default branch
   and our trusty bot account will release them to the repository.
-->
