### PR TITLE
chore: fix link in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -26,7 +26,7 @@
 
 * [ ] This PR contains a description of the changes I'm making
 * [ ] I updated the version in Chart.yaml
-* [ ] I updated the changelog with an `artifacthub.io/changes` annotation in `Chart.yaml`, check the [example](docs/development.md#Changelog) in the documentation.
+* [ ] I updated the changelog with an `artifacthub.io/changes` annotation in `Chart.yaml`, check the [example](/adfinis/helm-charts/blob/main/docs/development.md#Changelog) in the documentation.
 * [ ] I updated applicable README.md files using  `pre-commit run`
 * [ ] I documented any high-level concepts I'm introducing in `docs/`
 * [ ] CI is currently green and this is ready for review


### PR DESCRIPTION
# Description

Fix link to Changelog-docs in PR template.

# Checklist

This checklist is not really applicable for this PR.

* [x] This PR contains a description of the changes I'm making
* [ ] I updated the version in Chart.yaml
* [ ] I updated the changelog with an `artifacthub.io/changes` annotation in `Chart.yaml`, check the [example](docs/development.md#Changelog) in the documentation.
* [ ] I updated applicable README.md files using  `pre-commit run`
* [ ] I documented any high-level concepts I'm introducing in `docs/`
* [ ] CI is currently green and this is ready for review
* [ ] I am ready to test changes after they are applied and released
