### PR TITLE
Only create service with serviceMonitor

### DIFF
--- a/charts/vault-monitoring/Chart.yaml
+++ b/charts/vault-monitoring/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: vault-monitoring
 description: monitor your vault server from within Kubernetes' prometheus
 type: application
-version: 0.4.2
+version: 0.5.0
 home: https://github.com/adfinis/helm-charts/tree/main/charts/vault-monitoring
 sources:
   - https://github.com/adfinis/helm-charts/tree/main/charts/vault-monitoring
@@ -12,5 +12,5 @@ maintainers:
     url: https://adfinis.com
 annotations:
   artifacthub.io/changes: |
-    - kind: fixed
-      description: "fix metric for vault"
+    - kind: changed
+      description: "Only create service vault-monitoring when serviceMonitor.create=true"

--- a/charts/vault-monitoring/README.md
+++ b/charts/vault-monitoring/README.md
@@ -1,6 +1,6 @@
 # vault-monitoring
 
-![Version: 0.4.2](https://img.shields.io/badge/Version-0.4.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.5.0](https://img.shields.io/badge/Version-0.5.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 monitor your vault server from within Kubernetes' prometheus
 

--- a/charts/vault-monitoring/templates/service.yaml
+++ b/charts/vault-monitoring/templates/service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.serviceMonitor.create }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -17,3 +18,4 @@ spec:
     targetPort: {{ .Values.vault.port }}
   sessionAffinity: None
   type: {{ .Values.vault.service.type }}
+{{- end }}

--- a/charts/vault-monitoring/templates/service.yaml
+++ b/charts/vault-monitoring/templates/service.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.serviceMonitor.create }}
+{{- if .Values.vault.serviceMonitor.create }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/hack/chart-testing/ct.yaml
+++ b/hack/chart-testing/ct.yaml
@@ -4,8 +4,6 @@ chart-repos:
   - bitnami=https://charts.bitnami.com/bitnami
   - secrets-store-csi-driver=https://kubernetes-sigs.github.io/secrets-store-csi-driver/charts
   - grafana=https://grafana.github.io/helm-charts
-chart-dirs:
-  - charts
 additional-commands:
   - helm unittest --color {{ .Path }}
   - .tmp/bin/ah lint -p {{ .Path }}

--- a/hack/chart-testing/ct.yaml
+++ b/hack/chart-testing/ct.yaml
@@ -4,6 +4,8 @@ chart-repos:
   - bitnami=https://charts.bitnami.com/bitnami
   - secrets-store-csi-driver=https://kubernetes-sigs.github.io/secrets-store-csi-driver/charts
   - grafana=https://grafana.github.io/helm-charts
+chart-dirs:
+  - charts/vault-monitoring
 additional-commands:
   - helm unittest --color {{ .Path }}
   - .tmp/bin/ah lint -p {{ .Path }}

--- a/hack/chart-testing/ct.yaml
+++ b/hack/chart-testing/ct.yaml
@@ -5,7 +5,7 @@ chart-repos:
   - secrets-store-csi-driver=https://kubernetes-sigs.github.io/secrets-store-csi-driver/charts
   - grafana=https://grafana.github.io/helm-charts
 chart-dirs:
-  - charts/vault-monitoring
+  - charts
 additional-commands:
   - helm unittest --color {{ .Path }}
   - .tmp/bin/ah lint -p {{ .Path }}


### PR DESCRIPTION
Only create the service when `serviceMonitor.create` is set. The service is useless otherwise.

Background: I have a project where I can only use the `prometheusRules.enabled=true` but only want to use the prometheus rules, not the service monitor. Also, it creates a conflict in our deployment, because we already have a similar service with that name `vault-monitoring`.