### PR TITLE
chore(infra-apps): update mimir chart from 5.4.0 to 5.5.1

### DIFF
--- a/charts/infra-apps/Chart.yaml
+++ b/charts/infra-apps/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: infra-apps
 description: Argo CD app-of-apps config for infrastructure components
 type: application
-version: 0.224.1
+version: 0.225.0
 home: https://github.com/adfinis/helm-charts/tree/main/charts/infra-apps
 sources:
   - https://github.com/adfinis/helm-charts
@@ -18,11 +18,11 @@ annotations:
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |
     - kind: changed
-      description: "chore: Update cert-manager from 1.16.1 to 1.16.2"
+      description: "chore: Update mimir chart to 5.5.1, mimir version to 2.14.0"
       links:
-        - name: "cert-manager 1.16.2 Release"
-          url: "https://github.com/cert-manager/cert-manager/releases/tag/v1.16.2"
-        - name: "Restrict max size of PEM inputs"
-          url: https://github.com/cert-manager/cert-manager/pull/7401
-        - name: "Bump go + base images"
-          url: https://github.com/cert-manager/cert-manager/pull/7431
+        - name: "Grafana Mimir Release 2.14.0"
+          url: "https://github.com/grafana/mimir/releases/tag/mimir-2.14.0"
+        - name: "Grafana Mimir Helm Chart Release Notes 5.5"
+          url: "https://grafana.com/docs/helm-charts/mimir-distributed/latest/release-notes/v5.5/"
+        - name: "Grafana Mimir Helm Chart detailed Release Notes"
+          url: "https://github.com/grafana/mimir/blob/main/operations/helm/charts/mimir-distributed/CHANGELOG.md"

--- a/charts/infra-apps/README.md
+++ b/charts/infra-apps/README.md
@@ -1,6 +1,6 @@
 # infra-apps
 
-![Version: 0.224.1](https://img.shields.io/badge/Version-0.224.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.225.0](https://img.shields.io/badge/Version-0.225.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Argo CD app-of-apps config for infrastructure components
 
@@ -88,7 +88,7 @@ This chart is maintained by [Adfinis](https://adfinis.com/?pk_campaign=github&pk
 | mimir.destination.namespace | string | `"infra-mimir"` | Namespace |
 | mimir.enabled | bool | `false` | Enable mimir |
 | mimir.repoURL | string | [repo](https://grafana.github.io/helm-charts) | Repo URL |
-| mimir.targetRevision | string | `"5.4.0"` | [mimir Helm chart](https://github.com/grafana/mimir/tree/main/operations/helm/charts/mimir-distributed) |
+| mimir.targetRevision | string | `"5.5.1"` | [mimir Helm chart](https://github.com/grafana/mimir/tree/main/operations/helm/charts/mimir-distributed) |
 | mimir.values | object | [upstream values](https://github.com/grafana/mimir/tree/main/operations/helm/charts/mimir-distributed/values.yaml) | Helm values |
 | rbacManager | object | [example](./examples/rbac-manager.yaml) | [rbac-manager](https://fairwindsops.github.io/rbac-manager/) |
 | rbacManager.annotations | object | `{}` | Annotations for rbac-manager app |

--- a/charts/infra-apps/values.yaml
+++ b/charts/infra-apps/values.yaml
@@ -235,7 +235,7 @@ mimir:
   # -- Chart
   chart: mimir-distributed
   # -- [mimir Helm chart](https://github.com/grafana/mimir/tree/main/operations/helm/charts/mimir-distributed)
-  targetRevision: 5.4.0
+  targetRevision: 5.5.1
   # -- Helm values
   # @default -- [upstream values](https://github.com/grafana/mimir/tree/main/operations/helm/charts/mimir-distributed/values.yaml)
   values: {}


### PR DESCRIPTION
<!--
    Thank you for your contribution. Please use this template to help guide
    you towards preparing a PR that fullfills our merge requirements.
-->
# Description

<!-- Describe the changes your PR introduces here. -->
Update mimir chart from 5.4.0 to 5.5.1 and mimir from 2.13.0 to 2.14.0

Possibly relevant changes for Mimir 2.14.0
- Compactor adds a new `cortex_compactor_disk_out_of_space_errors_total` counter metric that tracks how many times a compaction fails due to the compactor being out of disk.
- The streaming of chunks from store-gateways to queriers is now enabled by default.
- The distributor now replies with the `Retry-After` header on retriable errors by default.
- Incoming OTLP requests were previously size-limited with the distributor's `-distributor.max-recv-msg-size` configuration.
The distributor has a new `-distributor.max-otlp-request-size` configuration for limiting OTLP requests. The default value is 100 MiB.
- Ingesters can be marked as read-only as part of their downscaling procedure.
- When running a remote read request, the querier honors the time range specified in the read hints.
- The default inactivity timeout of active series in ingesters is increased from 10m to 20m.
- Some timeout and concurrency settings changed for `store-gateway`
- (experimental) Redis caching is now deprecated. Users are encouraged to switch to Memcached.
- About a dozen previously deprecated features have been removed.
- The full changelog is available here: https://github.com/grafana/mimir/releases/tag/mimir-2.14.0 


# Issues

<!--
    Link related issues here, it's ok if this is empty but we do recommend that
    you create issues before working on PRs, issues on internal trackers are
    fine and need not be linked here.

    If your PR adds a new chart we expect you to create and link an issue so we
    can discuss adding your chart before you put the work into creating it.
-->

# Checklist

<!--
    Take care of the default items before marking your PR as ready for review,
    be prepared to add more items.
-->

* [x] This PR contains a description of the changes I'm making
* [x] I updated the version in Chart.yaml
* [x] I updated the changelog with an `artifacthub.io/changes` annotation in `Chart.yaml`, check the [example](/adfinis/helm-charts/blob/main/docs/development.md#Changelog) in the documentation.
* [x] I updated applicable README.md files using  `pre-commit run`
* [x] I documented any high-level concepts I'm introducing in `docs/`
* [x] CI is currently green and this is ready for review
* [x] I am ready to test changes after they are applied and released

<!--
    Please open PRs as Draft while you make CI green and/or finalise
    documentation. Your PR will be assigned to a CODEOWNER once you mark it
    as "Ready for Review".

   Once it is approved we will squash your changes onto the default branch
   and our trusty bot account will release them to the repository.
-->
