### PR TITLE
fix(etcd-backup): disallow concurrent job runs

### DIFF
--- a/charts/kubernetes-etcd-backup/Chart.yaml
+++ b/charts/kubernetes-etcd-backup/Chart.yaml
@@ -18,7 +18,7 @@ maintainers:
     email: support@adfinis.com
     url: https://adfinis.com
 annotations:
-  artifacthub.io/containsSecurityUpdates: "true"
+  artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |
     - kind: fixed
       description: "disallow concurrent job runs"

--- a/charts/kubernetes-etcd-backup/Chart.yaml
+++ b/charts/kubernetes-etcd-backup/Chart.yaml
@@ -3,7 +3,7 @@ apiVersion: v2
 name: kubernetes-etcd-backup
 description: Chart for kubernetes-etcd-backup solution
 type: application
-version: 1.4.1
+version: 1.4.2
 appVersion: v1.2.1
 keywords:
   - kubernetes-etcd-backup

--- a/charts/kubernetes-etcd-backup/Chart.yaml
+++ b/charts/kubernetes-etcd-backup/Chart.yaml
@@ -20,8 +20,5 @@ maintainers:
 annotations:
   artifacthub.io/containsSecurityUpdates: "true"
   artifacthub.io/changes: |
-    - kind: changed
-      description: "bump appVersion to v1.2.1"
-      links:
-        - name: "kubernetes-etcd-backup v1.2.1"
-          url: https://github.com/adfinis/kubernetes-etcd-backup/releases/tag/v1.2.1
+    - kind: fixed
+      description: "disallow concurrent job runs"

--- a/charts/kubernetes-etcd-backup/README.md
+++ b/charts/kubernetes-etcd-backup/README.md
@@ -1,6 +1,6 @@
 # kubernetes-etcd-backup
 
-![Version: 1.4.1](https://img.shields.io/badge/Version-1.4.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.2.1](https://img.shields.io/badge/AppVersion-v1.2.1-informational?style=flat-square)
+![Version: 1.4.2](https://img.shields.io/badge/Version-1.4.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.2.1](https://img.shields.io/badge/AppVersion-v1.2.1-informational?style=flat-square)
 
 Chart for kubernetes-etcd-backup solution
 

--- a/charts/kubernetes-etcd-backup/templates/cronjob.yaml
+++ b/charts/kubernetes-etcd-backup/templates/cronjob.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
   startingDeadlineSeconds: 600
   schedule: {{ .Values.backup.schedule | quote }}
+  concurrencyPolicy: Forbid
   jobTemplate:
     spec:
       # Retrying this job is not considered safe, because of that we fail the


### PR DESCRIPTION
<!--
    Thank you for your contribution. Please use this template to help guide
    you towards preparing a PR that fullfills our merge requirements.
-->
# Description

This PR sets the `concurrencyPolicy` for the `CronJob` in `kubernetes-etcd-backup` to `Forbid`, meaning we don't try to start a new Job while the old one is still running. In case it is, the new Job is skipped. 

# Issues

<!--
    Link related issues here, it's ok if this is empty but we do recommend that
    you create issues before working on PRs, issues on internal trackers are
    fine and need not be linked here.

    If your PR adds a new chart we expect you to create and link an issue so we
    can discuss adding your chart before you put the work into creating it.
-->

# Checklist

<!--
    Take care of the default items before marking your PR as ready for review,
    be prepared to add more items.
-->

* [x] This PR contains a description of the changes I'm making
* [x] I updated the version in Chart.yaml
* [x] I updated the changelog with an `artifacthub.io/changes` annotation in `Chart.yaml`, check the [example](/adfinis/helm-charts/blob/main/docs/development.md#Changelog) in the documentation.
* [x] I updated applicable README.md files using  `pre-commit run`
* [x] I documented any high-level concepts I'm introducing in `docs/`
* [x] CI is currently green and this is ready for review
* [x] I am ready to test changes after they are applied and released

<!--
    Please open PRs as Draft while you make CI green and/or finalise
    documentation. Your PR will be assigned to a CODEOWNER once you mark it
    as "Ready for Review".

   Once it is approved we will squash your changes onto the default branch
   and our trusty bot account will release them to the repository.
-->
