### PR TITLE
feat(cert-manager-monitoring): introduce critical severity for CertManagerCertExpirySoon alert

### DIFF
--- a/charts/cert-manager-monitoring/Chart.yaml
+++ b/charts/cert-manager-monitoring/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cert-manager-monitoring
 description: Monitor cert-manager with cert-manager-mixin.
 type: application
-version: 0.1.2
+version: 0.2.0
 keywords:
   - cert-manager
   - tls
@@ -16,3 +16,7 @@ maintainers:
   - name: adfinis
     email: support@adfinis.com
     url: https://adfinis.com
+annotations:
+  artifacthub.io/changes: |
+    - kind: changed
+      description: "introduce critical severity for CertManagerCertExpirySoon alert"

--- a/charts/cert-manager-monitoring/README.md
+++ b/charts/cert-manager-monitoring/README.md
@@ -1,6 +1,6 @@
 # cert-manager-monitoring
 
-![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Monitor cert-manager with cert-manager-mixin.
 

--- a/charts/cert-manager-monitoring/templates/prometheus/prometheusrule.yaml
+++ b/charts/cert-manager-monitoring/templates/prometheus/prometheusrule.yaml
@@ -44,6 +44,22 @@ spec:
       for: 1h
       labels:
         severity: warning
+    - alert: CertManagerCertExpirySoon
+      annotations:
+        dashboard_url: https://grafana.example.com/d/TvuRo2iMk/cert-manager
+        description: {{`The domain that this cert covers will be unavailable after {{ $value
+          | humanizeDuration }}. Clients using endpoints that this cert protects will start
+          to fail in {{ $value | humanizeDuration }}.`}}
+        runbook_url: https://gitlab.com/uneeq-oss/cert-manager-mixin/-/blob/master/RUNBOOK.md#certmanagercertexpirysoon
+        summary: {{`The cert '{{ $labels.name }}' is {{ $value | humanizeDuration }} from expiry,
+          it should have renewed over a week ago.`}}
+      expr: |
+        avg by (exported_namespace, namespace, name) (
+          certmanager_certificate_expiration_timestamp_seconds - time()
+        ) < (10 * 24 * 3600) # 10 days in seconds
+      for: 1h
+      labels:
+        severity: critical
     {{- end }}
     {{- if .Values.prometheus.rule.alerts.certnotready }}
     - alert: CertManagerCertNotReady


### PR DESCRIPTION
# Description

Introduce critical severity for CertManagerCertExpirySoon when cert will expire in less then 10 days

# Checklist

* [x] This PR contains a description of the changes I'm making
* [x] I updated the version in Chart.yaml
* [x] I updated the changelog with an `artifacthub.io/changes` annotation in `Chart.yaml`, check the [example](/adfinis/helm-charts/blob/main/docs/development.md#Changelog) in the documentation.
* [x] I updated applicable README.md files using  `pre-commit run`
* [x] I documented any high-level concepts I'm introducing in `docs/`
* [x] CI is currently green and this is ready for review
* [x] I am ready to test changes after they are applied and released