### PR TITLE
feat(infra-apps): update kube-prometheus-stack from 70.7.0 to 72.5.0

### DIFF
--- a/charts/infra-apps/Chart.yaml
+++ b/charts/infra-apps/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: infra-apps
 description: Argo CD app-of-apps config for infrastructure components
 type: application
-version: 0.235.0
+version: 0.236.0
 home: https://github.com/adfinis/helm-charts/tree/main/charts/infra-apps
 sources:
   - https://github.com/adfinis/helm-charts
@@ -19,19 +19,9 @@ annotations:
   artifacthub.io/changes: |
     - kind: changed
       description: |
-        chore: Update Argo CD from 2.14.8 to 2.14.11
+        chore: Update kube-prometheus-stack from 70.7.0 to 72.5.0
       links:
-        - name: Ugrade Argo CD to 2.14.11
-          url: https://github.com/argoproj/argo-helm/pull/3262
-        - name: Ugrade Argo CD to 2.14.10
-          url: https://github.com/argoproj/argo-helm/pull/3250
-        - name: Ugrade Argo CD to 2.14.9
-          url: https://github.com/argoproj/argo-helm/pull/3235
-        - name: Upgrade redis_exporter
-          url: https://github.com/argoproj/argo-helm/pull/3287
-        - name: Downgrade to latest available Redis under BSD-3-Clause
-          url: https://github.com/argoproj/argo-helm/pull/3271
-        - name: Update dex to 2.42.1
-          url: https://github.com/argoproj/argo-helm/pull/3251
-        - name: Same Secret name and key for all embedded redis options
-          url: https://github.com/argoproj/argo-helm/pull/3238
+        - name: Upgrade from 70.x to 71.x
+          url: https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/UPGRADE.md#from-70x-to-71x
+        - name: Upgrade from 71.x to 72.x
+          url: https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/UPGRADE.md#from-71x-to-72x

--- a/charts/infra-apps/README.md
+++ b/charts/infra-apps/README.md
@@ -1,6 +1,6 @@
 # infra-apps
 
-![Version: 0.235.0](https://img.shields.io/badge/Version-0.235.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.236.0](https://img.shields.io/badge/Version-0.236.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Argo CD app-of-apps config for infrastructure components
 
@@ -72,7 +72,7 @@ This chart is maintained by [Adfinis](https://adfinis.com/?pk_campaign=github&pk
 | kubePrometheusStack.enabled | bool | `false` | Enable prometheus-operator |
 | kubePrometheusStack.repoURL | string | [repo](https://prometheus-community.github.io/helm-charts) | Repo URL |
 | kubePrometheusStack.syncPolicy.syncOptions[0] | string | `"ServerSideApply=true"` | enable server-side-apply for KPS since it get's rid of having to manually sync/replace resources |
-| kubePrometheusStack.targetRevision | string | `"70.7.0"` | [kube-prometheus-stack Helm chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack) version |
+| kubePrometheusStack.targetRevision | string | `"72.5.0"` | [kube-prometheus-stack Helm chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack) version |
 | kubePrometheusStack.values | object | [upstream values](https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/values.yaml) | Helm values |
 | kured | object | [example](./examples/kured.yaml) | [kured](https://github.com/kubereboot/kured) |
 | kured.annotations | object | `{}` | Annotations for Kured app |

--- a/charts/infra-apps/values.yaml
+++ b/charts/infra-apps/values.yaml
@@ -130,7 +130,7 @@ kubePrometheusStack:
   # -- Chart
   chart: kube-prometheus-stack
   # -- [kube-prometheus-stack Helm chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack) version
-  targetRevision: 70.7.0
+  targetRevision: 72.5.0
   syncPolicy:
     syncOptions:
       # -- enable server-side-apply for KPS since it get's rid of having to manually sync/replace resources


### PR DESCRIPTION
# Description

Update kube-prometheus-stack to get prometheus-operator v0.82, which includes a fix for `metric_name_validation_scheme` not being rendered.

# Issues

- https://github.com/prometheus-operator/prometheus-operator/pull/7414

# Checklist

* [x] This PR contains a description of the changes I'm making
* [x] I updated the version in Chart.yaml
* [x] I updated the changelog with an `artifacthub.io/changes` annotation in `Chart.yaml`, check the [example](/adfinis/helm-charts/blob/main/docs/development.md#Changelog) in the documentation.
* [x] I updated applicable README.md files using  `pre-commit run`
* [x] I documented any high-level concepts I'm introducing in `docs/`
* [x] CI is currently green and this is ready for review
* [x] I am ready to test changes after they are applied and released