### PR TITLE
chore: upgrade kubernetes-etcd-backup to 1.4.6

### DIFF
--- a/charts/kubernetes-etcd-backup/Chart.yaml
+++ b/charts/kubernetes-etcd-backup/Chart.yaml
@@ -3,8 +3,8 @@ apiVersion: v2
 name: kubernetes-etcd-backup
 description: Chart for kubernetes-etcd-backup solution
 type: application
-version: 1.6.1
-appVersion: v1.4.3
+version: 1.6.2
+appVersion: v1.4.6
 keywords:
   - kubernetes-etcd-backup
   - kubernetes
@@ -18,18 +18,14 @@ maintainers:
     email: support@adfinis.com
     url: https://adfinis.com
 annotations:
-  artifacthub.io/containsSecurityUpdates: "true"
   artifacthub.io/changes: |
     - kind: changed
       description: |
-        upgrade openshift-etcd-backup image to v1.4.2
-
-        * stop leaking secrets to stdout
-        * bump base image
+        upgrade kubernetes-etcd-backup image to v1.4.6
       links:
-        - name: kubernetes-etcd-backup release v1.4.1
-          url: https://github.com/adfinis/kubernetes-etcd-backup/releases/tag/v1.4.1
-        - name: kubernetes-etcd-backup release v1.4.2
-          url: https://github.com/adfinis/kubernetes-etcd-backup/releases/tag/v1.4.2
-        - name: kubernetes-etcd-backup release v1.4.3
-          url: https://github.com/adfinis/kubernetes-etcd-backup/releases/tag/v1.4.3
+        - name: kubernetes-etcd-backup release v1.4.4
+          url: https://github.com/adfinis/kubernetes-etcd-backup/releases/tag/v1.4.4
+        - name: kubernetes-etcd-backup release v1.4.5
+          url: https://github.com/adfinis/kubernetes-etcd-backup/releases/tag/v1.4.5
+        - name: kubernetes-etcd-backup release v1.4.6
+          url: https://github.com/adfinis/kubernetes-etcd-backup/releases/tag/v1.4.6

--- a/charts/kubernetes-etcd-backup/README.md
+++ b/charts/kubernetes-etcd-backup/README.md
@@ -1,6 +1,6 @@
 # kubernetes-etcd-backup
 
-![Version: 1.6.1](https://img.shields.io/badge/Version-1.6.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.4.3](https://img.shields.io/badge/AppVersion-v1.4.3-informational?style=flat-square)
+![Version: 1.6.2](https://img.shields.io/badge/Version-1.6.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.4.6](https://img.shields.io/badge/AppVersion-v1.4.6-informational?style=flat-square)
 
 Chart for kubernetes-etcd-backup solution
 


### PR DESCRIPTION
# Description

Upgrade kubernetes-etcd-backup to 1.4.6, which moves ubi9-minimal from 9.5 to 9.6

# Issues

# Checklist

* [x] This PR contains a description of the changes I'm making
* [x] I updated the version in Chart.yaml
* [x] I updated the changelog with an `artifacthub.io/changes` annotation in `Chart.yaml`, check the [example](/adfinis/helm-charts/blob/main/docs/development.md#Changelog) in the documentation.
* [x] I updated applicable README.md files using  `pre-commit run`
* [x] I documented any high-level concepts I'm introducing in `docs/`
* [x] CI is currently green and this is ready for review
* [x] I am ready to test changes after they are applied and released