### PR TITLE
chore: upgrade openshift-etcd-backup to 1.9.5

### DIFF
--- a/charts/openshift-etcd-backup/Chart.yaml
+++ b/charts/openshift-etcd-backup/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: openshift-etcd-backup
 description: Chart for openshift-etcd-backup solution
 type: application
-version: 1.9.3
-appVersion: v1.9.3
+version: 1.9.5
+appVersion: v1.9.5
 keywords:
   - openshift-etcd-backup
   - openshift
@@ -18,16 +18,12 @@ maintainers:
     email: support@adfinis.com
     url: https://adfinis.com
 annotations:
-  artifacthub.io/containsSecurityUpdates: "true"
   artifacthub.io/changes: |
     - kind: changed
       description: |
-        upgrade openshift-etcd-backup image to v1.9.3
-
-        * stop leaking secrets to stdout
-        * make s3 policy setup optional
+        upgrade openshift-etcd-backup image to v1.9.5
       links:
-        - name: openshift-etcd-backup release v1.9.2
-          url: https://github.com/adfinis/openshift-etcd-backup/releases/tag/v1.9.2
-        - name: openshift-etcd-backup release v1.9.3
-          url: https://github.com/adfinis/openshift-etcd-backup/releases/tag/v1.9.3
+        - name: openshift-etcd-backup release v1.9.4
+          url: https://github.com/adfinis/openshift-etcd-backup/releases/tag/v1.9.4
+        - name: openshift-etcd-backup release v1.9.5
+          url: https://github.com/adfinis/openshift-etcd-backup/releases/tag/v1.9.5

--- a/charts/openshift-etcd-backup/README.md
+++ b/charts/openshift-etcd-backup/README.md
@@ -1,6 +1,6 @@
 # openshift-etcd-backup
 
-![Version: 1.9.3](https://img.shields.io/badge/Version-1.9.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.9.3](https://img.shields.io/badge/AppVersion-v1.9.3-informational?style=flat-square)
+![Version: 1.9.5](https://img.shields.io/badge/Version-1.9.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.9.5](https://img.shields.io/badge/AppVersion-v1.9.5-informational?style=flat-square)
 
 Chart for openshift-etcd-backup solution
 


### PR DESCRIPTION
# Description

Upgrade openshift-etcd-backup to 1.9.5, which upgrades ubi9-minimal from 9.5 to 9.6

# Issues

# Checklist

* [x] This PR contains a description of the changes I'm making
* [x] I updated the version in Chart.yaml
* [x] I updated the changelog with an `artifacthub.io/changes` annotation in `Chart.yaml`, check the [example](/adfinis/helm-charts/blob/main/docs/development.md#Changelog) in the documentation.
* [x] I updated applicable README.md files using  `pre-commit run`
* [x] I documented any high-level concepts I'm introducing in `docs/`
* [x] CI is currently green and this is ready for review
* [x] I am ready to test changes after they are applied and released