### PR TITLE
openshift etcd backup: set pod dns policy to ClusterFirstWithHostNet

### DIFF
--- a/charts/openshift-etcd-backup/Chart.yaml
+++ b/charts/openshift-etcd-backup/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: openshift-etcd-backup
 description: Chart for openshift-etcd-backup solution
 type: application
-version: 1.9.6
-appVersion: v1.9.6
+version: 1.9.7
+appVersion: v1.9.7
 keywords:
   - openshift-etcd-backup
   - openshift
@@ -21,9 +21,4 @@ annotations:
   artifacthub.io/changes: |
     - kind: changed
       description: |
-        upgrade openshift-etcd-backup image to v1.9.6
-
-        * fixed prometheus alert
-      links:
-        - name: openshift-etcd-backup release v1.9.6
-          url: https://github.com/adfinis/openshift-etcd-backup/releases/tag/v1.9.6
+        set pod's dns policy to ClusterFirstWithHostNet

--- a/charts/openshift-etcd-backup/Chart.yaml
+++ b/charts/openshift-etcd-backup/Chart.yaml
@@ -21,4 +21,9 @@ annotations:
   artifacthub.io/changes: |
     - kind: changed
       description: |
-        set pod's dns policy to ClusterFirstWithHostNet
+        upgrade openshift-etcd-backup image to v1.9.6
+        * set pod's dns policy to ClusterFirstWithHostNet
+
+      links:
+        - name: openshift-etcd-backup release v1.9.7
+          url: https://github.com/adfinis/openshift-etcd-backup/releases/tag/v1.9.7

--- a/charts/openshift-etcd-backup/Chart.yaml
+++ b/charts/openshift-etcd-backup/Chart.yaml
@@ -21,7 +21,7 @@ annotations:
   artifacthub.io/changes: |
     - kind: changed
       description: |
-        upgrade openshift-etcd-backup image to v1.9.6
+        upgrade openshift-etcd-backup image to v1.9.7
         * set pod's dns policy to ClusterFirstWithHostNet
 
       links:

--- a/charts/openshift-etcd-backup/README.md
+++ b/charts/openshift-etcd-backup/README.md
@@ -1,6 +1,6 @@
 # openshift-etcd-backup
 
-![Version: 1.9.6](https://img.shields.io/badge/Version-1.9.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.9.6](https://img.shields.io/badge/AppVersion-v1.9.6-informational?style=flat-square)
+![Version: 1.9.7](https://img.shields.io/badge/Version-1.9.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.9.7](https://img.shields.io/badge/AppVersion-v1.9.7-informational?style=flat-square)
 
 Chart for openshift-etcd-backup solution
 

--- a/charts/openshift-etcd-backup/templates/cronjob.yaml
+++ b/charts/openshift-etcd-backup/templates/cronjob.yaml
@@ -97,3 +97,4 @@ spec:
             configMap:
               name: {{ include "openshift-etcd-backup.fullname" . }}-ca-inject
           {{- end }}
+          dnsPolicy: ClusterFirstWithHostNet


### PR DESCRIPTION
# Description

This changes sets the pod DNS policy to `ClusterFirstWithHostNet`

# Issues

Pod runs with DNS policy set to `ClusterFirst`. Pods running with hostNetwork  should explicitly set its DNS policy to `ClusterFirstWithHostNet` ([doc](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy))

# Checklist

* [x] This PR contains a description of the changes I'm making
* [x] I updated the version in Chart.yaml
* [x] I updated the changelog with an `artifacthub.io/changes` annotation in `Chart.yaml`, check the [example](/adfinis/helm-charts/blob/main/docs/development.md#Changelog) in the documentation.
* [x] I updated applicable README.md files using  `pre-commit run`
* [x] I documented any high-level concepts I'm introducing in `docs/`
* [x] CI is currently green and this is ready for review
* [x] I am ready to test changes after they are applied and released

