### PR TITLE
chore(storage-apps): bumping csiDriverSmb chart version

### DIFF
--- a/charts/storage-apps/Chart.yaml
+++ b/charts/storage-apps/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: storage-apps
 description: Argo CD app-of-apps config for storage applications
 type: application
-version: 0.17.0
+version: 0.18.0
 home: https://github.com/adfinis/helm-charts/tree/main/charts/storage-apps
 sources:
   - https://github.com/adfinis/helm-charts
@@ -18,25 +18,13 @@ annotations:
   artifacthub.io/containsSecurityUpdates: "true"
   artifacthub.io/changes: |
     - kind: changed
-      description: "update minio to 5.14.0"
+      description: "Updated csiDriverSmb from 1.14.0 to 1.18.0"
       links:
-        - name: Github release
-          url: https://github.com/minio/minio/releases/tag/RELEASE.2024-12-18T13-15-44Z
-        - name: Github release
-          url: https://github.com/minio/minio/releases/tag/RELEASE.2024-12-13T22-19-12Z
-        - name: Github release
-          url: https://github.com/minio/minio/releases/tag/RELEASE.2024-11-07T00-52-20Z
-        - name: Github release
-          url: https://github.com/minio/minio/releases/tag/RELEASE.2024-07-16T23-46-41Z
-        - name: Github release
-          url: https://github.com/minio/minio/releases/tag/RELEASE.2024-07-15T19-02-30Z
-        - name: Github release
-          url: https://github.com/minio/minio/releases/tag/RELEASE.2024-07-13T01-46-15Z
-        - name: Github release
-          url: https://github.com/minio/minio/releases/tag/RELEASE.2024-01-31T20-20-33Z
-        - name: Github release
-          url: https://github.com/minio/minio/releases/tag/RELEASE.2024-01-01T16-36-33Z
-        - name: Github release
-          url: https://github.com/minio/minio/releases/tag/RELEASE.2023-12-09T18-17-51Z
-        - name: Github release
-          url: https://github.com/minio/minio/releases/tag/RELEASE.2023-12-02T10-51-33Z
+        - name: v1.18.0 release
+          url: https://github.com/kubernetes-csi/csi-driver-smb/releases/tag/v1.18.0
+        - name: v1.17.0 release
+          url: https://github.com/kubernetes-csi/csi-driver-smb/releases/tag/v1.17.0
+        - name: v1.16.0 release
+          url: https://github.com/kubernetes-csi/csi-driver-smb/releases/tag/v1.16.0
+        - name: v1.15.0 release
+          url: https://github.com/kubernetes-csi/csi-driver-smb/releases/tag/v1.15.0

--- a/charts/storage-apps/README.md
+++ b/charts/storage-apps/README.md
@@ -1,6 +1,6 @@
 # storage-apps
 
-![Version: 0.17.0](https://img.shields.io/badge/Version-0.17.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.18.0](https://img.shields.io/badge/Version-0.18.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Argo CD app-of-apps config for storage applications
 
@@ -42,7 +42,7 @@ This chart is maintained by [Adfinis](https://adfinis.com/?pk_campaign=github&pk
 | csiDriverSmb.destination.namespace | string | `"infra-csi-driver-smb"` | Namespace |
 | csiDriverSmb.enabled | bool | `false` | Enable csi-driver-smb |
 | csiDriverSmb.repoURL | string | [repo](https://raw.githubusercontent.com/kubernetes-csi/csi-driver-smb/master/charts) | Repo URL |
-| csiDriverSmb.targetRevision | string | `"1.14.0"` | [csi-driver-smb Helm chart](https://github.com/kubernetes-csi/csi-driver-smb/tree/master/charts) version |
+| csiDriverSmb.targetRevision | string | `"1.18.0"` | [csi-driver-smb Helm chart](https://github.com/kubernetes-csi/csi-driver-smb/tree/master/charts) version |
 | csiDriverSmb.values | object | [upstream values](https://github.com/kubernetes-csi/csi-driver-smb/blob/master/charts/latest/csi-driver-smb/values.yaml) | Helm values |
 | minio | object | - | [minio](https://github.com/minio/minio) |
 | minio.chart | string | `"minio"` | Chart |

--- a/charts/storage-apps/values.yaml
+++ b/charts/storage-apps/values.yaml
@@ -53,7 +53,7 @@ csiDriverSmb:
   # -- Chart
   chart: "csi-driver-smb"
   # -- [csi-driver-smb Helm chart](https://github.com/kubernetes-csi/csi-driver-smb/tree/master/charts) version
-  targetRevision: "1.14.0"
+  targetRevision: "1.18.0"
   # -- Helm values
   # @default -- [upstream values](https://github.com/kubernetes-csi/csi-driver-smb/blob/master/charts/latest/csi-driver-smb/values.yaml)
   values: {}


### PR DESCRIPTION
<!--
    Thank you for your contribution. Please use this template to help guide
    you towards preparing a PR that fullfills our merge requirements.
-->
# Description

This updates the csiDriverSmb chart from 1.14.0 to 1.18.0.
I tested the upgrade on a local dev cluster, since we do not use this csi driver on AKS INT or test.

# Issues

https://github.com/adfinis/helm-charts/issues/1467

<!--
    Link related issues here, it's ok if this is empty but we do recommend that
    you create issues before working on PRs, issues on internal trackers are
    fine and need not be linked here.

    If your PR adds a new chart we expect you to create and link an issue so we
    can discuss adding your chart before you put the work into creating it.
-->

# Checklist

<!--
    Take care of the default items before marking your PR as ready for review,
    be prepared to add more items.
-->

* [x] This PR contains a description of the changes I'm making
* [x] I updated the version in Chart.yaml
* [x] I updated the changelog with an `artifacthub.io/changes` annotation in `Chart.yaml`, check the [example](/adfinis/helm-charts/blob/main/docs/development.md#Changelog) in the documentation.
* [x] I updated applicable README.md files using  `pre-commit run`
* [x] I documented any high-level concepts I'm introducing in `docs/`
* [ ] CI is currently green and this is ready for review
* [x] I am ready to test changes after they are applied and released

<!--
    Please open PRs as Draft while you make CI green and/or finalise
    documentation. Your PR will be assigned to a CODEOWNER once you mark it
    as "Ready for Review".

   Once it is approved we will squash your changes onto the default branch
   and our trusty bot account will release them to the repository.
-->
