### PR TITLE
chore(security-apps): bumping kyvernoPolicies chart version

### DIFF
--- a/charts/security-apps/Chart.yaml
+++ b/charts/security-apps/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: security-apps
 description: Argo CD app-of-apps config for security applications
 type: application
-version: 0.101.2
+version: 0.102.0
 home: https://github.com/adfinis/helm-charts/tree/main/charts/security-apps
 sources:
   - https://github.com/adfinis/helm-charts
@@ -18,4 +18,9 @@ annotations:
   artifacthub.io/changes: |
     - kind: changed
       description: |
-        chore: Marked falco as deprecated since we no longer use it internally.
+        chore: Updated kyverno-policies form 3.4.1 to 3.5.1 inline with the main kyverno Chart.
+        Changes:
+          - Removed the deprecated top-level field spec.validationFailureAction.
+          - Added the new per-rule field spec.validate[*].failureAction as its replacement. Please update your policies to use the new field.
+          - Added the spec.validate[*].allowExistingViolations field to policies, which allows existing resources to be exempt from validation rules.
+          - Fixed a bug in the merging logic for policyExclude customizations to prevent incorrect overrides.

--- a/charts/security-apps/README.md
+++ b/charts/security-apps/README.md
@@ -1,6 +1,6 @@
 # security-apps
 
-![Version: 0.101.2](https://img.shields.io/badge/Version-0.101.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.102.0](https://img.shields.io/badge/Version-0.102.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Argo CD app-of-apps config for security applications
 
@@ -80,7 +80,7 @@ This chart is maintained by [Adfinis](https://adfinis.com/?pk_campaign=github&pk
 | kyvernoPolicies.destination.namespace | string | `"infra-kyverno"` | Namespace |
 | kyvernoPolicies.enabled | bool | `false` | Enable kyverno-policies |
 | kyvernoPolicies.repoURL | string | [repo](https://kyverno.github.io/kyverno/) | Repo URL |
-| kyvernoPolicies.targetRevision | string | `"3.4.1"` | [kyverno Helm chart](https://github.com/kyverno/kyverno/tree/main/charts/kyverno-policies) |
+| kyvernoPolicies.targetRevision | string | `"3.5.1"` | [kyverno Helm chart](https://github.com/kyverno/kyverno/tree/main/charts/kyverno-policies) |
 | kyvernoPolicies.values | object | [upstream values](https://github.com/kyverno/kyverno/blob/main/charts/kyverno-policies/values.yaml) | Helm values |
 | neuvector | object | - | [NeuVector](https://github.com/neuvector/neuvector) ([example](./example/neuvector.yaml)) |
 | neuvector.chart | string | `"core"` | Chart |

--- a/charts/security-apps/values.yaml
+++ b/charts/security-apps/values.yaml
@@ -327,7 +327,7 @@ kyvernoPolicies:
   # -- Chart
   chart: kyverno-policies
   # -- [kyverno Helm chart](https://github.com/kyverno/kyverno/tree/main/charts/kyverno-policies)
-  targetRevision: 3.4.1
+  targetRevision: 3.5.1
   # -- Helm values
   # @default -- [upstream values](https://github.com/kyverno/kyverno/blob/main/charts/kyverno-policies/values.yaml)
   values: {}


### PR DESCRIPTION
<!--
    Thank you for your contribution. Please use this template to help guide
    you towards preparing a PR that fullfills our merge requirements.
-->
# Description

Updated kyverno-policies form 3.4.1 to 3.5.1 in line with the main kyverno Chart.
No links to the changes were provided, since kyverno does not properly publish a changelog for its charts.
I tested the upgrade on a local dev cluster, since we do not use kyvernoPolicies on AKS INT prod or test.
Changes:
- Removed the deprecated top-level field spec.validationFailureAction.
- Added the new per-rule field spec.validate[*].failureAction as its replacement. Please update your policies to use the new field.
- Added the spec.validate[*].allowExistingViolations field to policies, which allows existing resources to be exempt from validation rules.
- Fixed a bug in the merging logic for policyExclude customizations to prevent incorrect overrides.


<!-- Describe the changes your PR introduces here. -->

# Issues
https://github.com/adfinis/helm-charts/issues/1464
<!--
    Link related issues here, it's ok if this is empty but we do recommend that
    you create issues before working on PRs, issues on internal trackers are
    fine and need not be linked here.

    If your PR adds a new chart we expect you to create and link an issue so we
    can discuss adding your chart before you put the work into creating it.
-->

# Checklist

<!--
    Take care of the default items before marking your PR as ready for review,
    be prepared to add more items.
-->

* [x] This PR contains a description of the changes I'm making
* [x] I updated the version in Chart.yaml
* [x] I updated the changelog with an `artifacthub.io/changes` annotation in `Chart.yaml`, check the [example](/adfinis/helm-charts/blob/main/docs/development.md#Changelog) in the documentation.
* [x] I updated applicable README.md files using  `pre-commit run`
* [x] I documented any high-level concepts I'm introducing in `docs/`
* [x] CI is currently green and this is ready for review
* [x] I am ready to test changes after they are applied and released

<!--
    Please open PRs as Draft while you make CI green and/or finalise
    documentation. Your PR will be assigned to a CODEOWNER once you mark it
    as "Ready for Review".

   Once it is approved we will squash your changes onto the default branch
   and our trusty bot account will release them to the repository.
-->
