### PR TITLE
feat(infra-apps): Update Mimir from 2.17.0 to 3.1.2

### DIFF
--- a/charts/infra-apps/Chart.yaml
+++ b/charts/infra-apps/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: infra-apps
 description: Argo CD app-of-apps config for infrastructure components
 type: application
-version: 0.273.0
+version: 0.274.0
 home: https://github.com/adfinis/helm-charts/tree/main/charts/infra-apps
 sources:
   - https://github.com/adfinis/helm-charts
@@ -19,15 +19,21 @@ annotations:
   artifacthub.io/changes: |
     - kind: changed
       description: |
-        feat: Update rbac-manager from v1.9.5 to v1.10.0
+        feat!: Update Mimir from 2.17.0 to 3.1.2
 
-        - Update Helm chart from 1.21.5 to 2.0.0
-        - Change image repository to GAR (pkg.dev)
-        - Immutable, signed images replace floating tags (like `v1`)
+        - Update Helm chart from 5.8.0 to 6.1.0
+        - Update base image from Debian 12 to 13
+        - Update Golang and other security deps
+        - More Kafka options for Ingest storage
+        - Mimir Query Engine (MQE) improvements
+        - Zone-aware memberlist routing
+        - Ingest storage architecture (new Kafka based default)
       links:
-        - name: Helm Chart Change
-          url: https://github.com/FairwindsOps/charts/pull/1864
-        - name: RBAC Manager v1.10.0
-          url: https://github.com/FairwindsOps/rbac-manager/releases/tag/v1.10.0
-        - name: Upgrade Guide
-          url: https://github.com/FairwindsOps/rbac-manager#notice-registry-migration-and-immutable-images-v195--v1100
+        - name: Mimir 3.1.2
+          url: https://github.com/grafana/mimir/releases/tag/mimir-3.1.2
+        - name: Mimir 3.1.1
+          url: https://github.com/grafana/mimir/releases/tag/mimir-3.1.1
+        - name: Mimir 3.1.0
+          url: https://github.com/grafana/mimir/releases/tag/mimir-3.1.0
+        - name: Mimir 3.0.0
+          url: https://github.com/grafana/mimir/releases/tag/mimir-3.0.0

--- a/charts/infra-apps/README.md
+++ b/charts/infra-apps/README.md
@@ -1,6 +1,6 @@
 # infra-apps
 
-![Version: 0.273.0](https://img.shields.io/badge/Version-0.273.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.274.0](https://img.shields.io/badge/Version-0.274.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Argo CD app-of-apps config for infrastructure components
 
@@ -88,7 +88,7 @@ This chart is maintained by [Adfinis](https://adfinis.com/?pk_campaign=github&pk
 | mimir.destination.namespace | string | `"infra-mimir"` | Namespace |
 | mimir.enabled | bool | `false` | Enable mimir |
 | mimir.repoURL | string | [repo](https://grafana.github.io/helm-charts) | Repo URL |
-| mimir.targetRevision | string | `"5.8.0"` | [mimir Helm chart](https://github.com/grafana/mimir/tree/main/operations/helm/charts/mimir-distributed) |
+| mimir.targetRevision | string | `"6.1.0"` | [mimir Helm chart](https://github.com/grafana/mimir/tree/main/operations/helm/charts/mimir-distributed) |
 | mimir.values | object | [upstream values](https://github.com/grafana/mimir/tree/main/operations/helm/charts/mimir-distributed/values.yaml) | Helm values |
 | rbacManager | object | [example](./examples/rbac-manager.yaml) | [rbac-manager](https://fairwindsops.github.io/rbac-manager/) |
 | rbacManager.annotations | object | `{}` | Annotations for rbac-manager app |

--- a/charts/infra-apps/values.yaml
+++ b/charts/infra-apps/values.yaml
@@ -236,7 +236,7 @@ mimir:
   # -- Chart
   chart: mimir-distributed
   # -- [mimir Helm chart](https://github.com/grafana/mimir/tree/main/operations/helm/charts/mimir-distributed)
-  targetRevision: 5.8.0
+  targetRevision: 6.1.0
   # -- Helm values
   # @default -- [upstream values](https://github.com/grafana/mimir/tree/main/operations/helm/charts/mimir-distributed/values.yaml)
   values: {}


### PR DESCRIPTION
<!--
    Thank you for your contribution. Please use this template to help guide
    you towards preparing a PR that fullfills our merge requirements.
-->
# Description

Update Mimir with many changes and patches.

# Issues

<!--
    Link related issues here, it's ok if this is empty but we do recommend that
    you create issues before working on PRs, issues on internal trackers are
    fine and need not be linked here.

    If your PR adds a new chart we expect you to create and link an issue so we
    can discuss adding your chart before you put the work into creating it.
-->
* fixes #1812
* fixes #1886

# Checklist

<!--
    Take care of the default items before marking your PR as ready for review,
    be prepared to add more items.
-->

* [x] This PR contains a description of the changes I'm making
* [x] I updated the version in Chart.yaml
* [x] I updated the changelog with an `artifacthub.io/changes` annotation in `Chart.yaml`, check the [example](/adfinis/helm-charts/blob/main/docs/development.md#Changelog) in the documentation.
* [x] I updated applicable README.md files using  `pre-commit run`
* [x] I documented any high-level concepts I'm introducing in `docs/`
* [x] CI is currently green and this is ready for review
* [x] I am ready to test changes after they are applied and released

<!--
    Please open PRs as Draft while you make CI green and/or finalise
    documentation. Your PR will be assigned to a CODEOWNER once you mark it
    as "Ready for Review".

   Once it is approved we will squash your changes onto the default branch
   and our trusty bot account will release them to the repository.
-->

## Update Notes

Mimir v3.x will deploy a non-production grade Kafka ensemble as part of the new [ingest storage architecture](https://grafana.com/docs/mimir/latest/get-started/about-grafana-mimir-architecture/about-ingest-storage-architecture/). If you are not ready yet to switch your deployment to Kafka yet, then you can use the following diff as guidance for falling back to the classic ingest architecture w/o Kafka.

```diff
--- mimir.final.yaml	2026-07-07 17:21:20.743622674 +0200
+++ mimir.final-classic.yaml	2026-07-07 17:21:40.129005293 +0200
@@ -31,5 +31,15 @@
       ingestion_burst_size: 400000
       ingestion_rate: 20000
       max_global_series_per_user: 0
+    ingest_storage:
+      enabled: false
+      kafka:
+        address: null
+        topic: null
+        auto_create_topic_default_partitions: null
+    ingester:
+      push_grpc_method_enabled: true
 rollout_operator:
   enabled: false
+kafka:
+  enabled: false
```

We recommend that you start planning a right sized Kafka deployment since this the classic ingest architecture is currently deprecated.