### PR TITLE
feat(misc-apps): Bump OpenCost chart to 2.5.30

### DIFF
--- a/charts/misc-apps/Chart.yaml
+++ b/charts/misc-apps/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: misc-apps
 description: Argo CD app-of-apps config for miscellaneous small tools
 type: application
-version: 0.76.0
+version: 0.77.0
 home: https://github.com/adfinis/helm-charts/tree/main/charts/misc-apps
 sources:
   - https://github.com/adfinis/helm-charts
@@ -19,11 +19,13 @@ annotations:
   artifacthub.io/changes: |
     - kind: changed
       description: |
-        Updated Goldilocks chart from 10.4.1 to 11.1.0, including:
-          - Goldilocks application update from v4.14.1 to v4.16.1
-          - Optional VPA chart dependency update from 4.12.* to 5.0.*
+        Updated OpenCost chart from 2.5.26 to 2.5.30, including:
+          - OpenCost application update from 1.120.4 to 1.121.1
+          - Add inference-cost configuration support, disabled by default
+          - Add external labels configuration for OpenCost users
+          - Add opencost.exporter.extraEnvFrom for ConfigMap and Secret sources
       links:
-        - name: "Goldilocks chart 11.1.0"
-          url: https://artifacthub.io/packages/helm/fairwinds-stable/goldilocks/11.1.0
-        - name: "Goldilocks releases"
-          url: https://github.com/FairwindsOps/goldilocks/releases
+        - name: "OpenCost chart 2.5.30"
+          url: https://artifacthub.io/packages/helm/opencost/opencost/2.5.30
+        - name: "Chart changes from 2.5.26 to 2.5.30"
+          url: https://github.com/opencost/opencost-helm-chart/compare/opencost-2.5.26...opencost-2.5.30

--- a/charts/misc-apps/README.md
+++ b/charts/misc-apps/README.md
@@ -1,6 +1,6 @@
 # misc-apps
 
-![Version: 0.76.0](https://img.shields.io/badge/Version-0.76.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.77.0](https://img.shields.io/badge/Version-0.77.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 Argo CD app-of-apps config for miscellaneous small tools
 
@@ -82,7 +82,7 @@ This chart is maintained by [Adfinis](https://adfinis.com/?pk_campaign=github&pk
 | opencost.destination.namespace | string | `"infra-opencost"` | Namespace |
 | opencost.enabled | bool | `false` | Enable OpenCost |
 | opencost.repoURL | string | [repo](https://opencost.github.io/opencost-helm-chart) | Repo URL |
-| opencost.targetRevision | string | `"2.5.26"` | [OpenCost Helm chart](https://github.com/opencost/opencost-helm-chart/tree/main/charts/opencost) |
+| opencost.targetRevision | string | `"2.5.30"` | [OpenCost Helm chart](https://github.com/opencost/opencost-helm-chart/tree/main/charts/opencost) |
 | opencost.values | object | [upstream values](https://github.com/opencost/opencost-helm-chart/blob/main/charts/opencost/values.yaml) | Helm values |
 | prometheusMsteams | object | - | [prometheus-msteams](https://github.com/prometheus-msteams/prometheus-msteams) ([example](./example/prometheus-msteams.yaml)) |
 | prometheusMsteams.chart | string | `"prometheus-msteams"` | Chart |

--- a/charts/misc-apps/values.yaml
+++ b/charts/misc-apps/values.yaml
@@ -206,7 +206,7 @@ opencost:
   # -- Chart
   chart: opencost
   # -- [OpenCost Helm chart](https://github.com/opencost/opencost-helm-chart/tree/main/charts/opencost)
-  targetRevision: 2.5.26
+  targetRevision: 2.5.30
   # -- Helm values
   # @default -- [upstream values](https://github.com/opencost/opencost-helm-chart/blob/main/charts/opencost/values.yaml)
   values: {}


### PR DESCRIPTION
<!--
    Thank you for your contribution. Please use this template to help guide
    you towards preparing a PR that fullfills our merge requirements.
-->
# Description

<!-- Describe the changes your PR introduces here. -->
Bump OpenCost chart to 2.5.30
# Issues
fixes: https://github.com/adfinis/helm-charts/issues/1969
<!--
    Link related issues here, it's ok if this is empty but we do recommend that
    you create issues before working on PRs, issues on internal trackers are
    fine and need not be linked here.

    If your PR adds a new chart we expect you to create and link an issue so we
    can discuss adding your chart before you put the work into creating it.

    We ask you to use the following format for linking issues:

    * fixes #<NUMBER>

    By formatting the link in a list and with the "fixes" prefix, the issue
    will be autoclosed on merge and the title of the issue will be displayed
    in the description.
-->

# Checklist

<!--
    Take care of the default items before marking your PR as ready for review,
    be prepared to add more items.
-->

* [x] This PR contains a description of the changes I'm making
* [x] I updated the version in Chart.yaml
* [x] I updated the changelog with an `artifacthub.io/changes` annotation in `Chart.yaml`, check the [example](/adfinis/helm-charts/blob/main/docs/development.md#Changelog) in the documentation.
* [x] I updated applicable README.md files using  `pre-commit run`
* [x] I documented any high-level concepts I'm introducing in `docs/`
* [x] CI is currently green and this is ready for review
* [x] I am ready to test changes after they are applied and released

<!--
    Please open PRs as Draft while you make CI green and/or finalise
    documentation. Your PR will be assigned to a CODEOWNER once you mark it
    as "Ready for Review".

   Once it is approved we will squash your changes onto the default branch
   and our trusty bot account will release them to the repository.
-->
